### PR TITLE
Cubic + Chain

### DIFF
--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -66,6 +66,10 @@ include("utils/split_model.jl")
 #Clapeyron methods (AD, property solvers, etc)
 include("methods/methods.jl")
 
+#misc
+include("utils/misc.jl")
+
+
 #=
 the dependency chain is the following:
 
@@ -158,5 +162,5 @@ include("models/ECS/variants/SPUNG.jl")
 include("models/PeTS/PeTS.jl")
 include("models/UFTheory/UFTheory.jl")
 include("models/AnalyticalSLV/AnalyticalSLV.jl")
-include("utils/misc.jl")
+include("models/CPC/CPC.jl")
 end # module

--- a/src/models/CPC/CPC.jl
+++ b/src/models/CPC/CPC.jl
@@ -1,0 +1,65 @@
+abstract type CubicPlusChainModel <: EoSModel end
+abstract type CPCRDFModel <: EoSModel end
+
+struct CubicPlusChain{M} <: CubicPlusChainModel
+    components::Vector{String}
+    cubicmodel::M
+    references::Vector{String}
+end
+
+include("chainmodel/chainmodel.jl")
+include("cubicmodel/cubicmodel.jl")
+
+function CubicPlusChain(components::Vector{String}; 
+    idealmodel=BasicIdeal,
+    cubicmodel = RK,
+    alpha,
+    mixing,
+    rdf = ElliottRDF,
+    translation=NoTranslation,
+    userlocations=String[], 
+    ideal_userlocations=String[],
+    alpha_userlocations = String[],
+    mixing_userlocations = String[],
+    rdf_userlocations = String[],
+    translation_userlocations = String[],
+    verbose=false)
+
+    #hack: we supplant activity with rdf
+    activity = rdf
+    activity_userlocations = rdf_userlocations
+
+    cubic = cubicmodel(components;idealmodel,alpha,mixing,translation,activity,userlocations,ideal_userlocations,alpha_userlocations,mixing_userlocations,translation_userlocations,activity_userlocations,verbose)
+    references = ["10.1021/acs.iecr.9b00435","10.1021/acs.iecr.9b00436","10.1021/acs.iecr.0c02483"]
+    return CubicPlusChain(components,cubic,references)
+end
+
+idealmodel(model::CubicPlusChainModel) = idealmodel(model.cubicmodel)
+
+function a_res(model::CubicPlusChainModel,V,T,z,_data = @f(data))
+    cubicdata,m̄,β = _data
+    return m̄*a_res(model.cubicmodel,V,T,z,cubicdata) + a_chain(model,V,T,z,_data)
+end
+
+function g_rdf end
+
+function a_chain(model::CubicPlusChainModel,V,T,z,_data = @f(data))
+    cubicdata,m̄,β = data
+    RDF = model.cubicmodel.mixing.rdf
+    return (m̄ - 1)*log(g_rdf(RDF,β))
+end
+
+function data(model::CubicPlusChainModel,V,T,z)
+    m = model.cubicmodel.mixing.params.segment.values
+    m̄ = dot(m,z)/∑z
+    cubicdata = data(model.cubicmodel,V,T,z)
+    ∑z,a,b,c = cubicdata
+    β = ∑z*m̄*b/V
+    return cubicdata,m̄,β
+end
+
+include("variants/CPC_RKE.jl")
+include("variants/CPC_SRKE.jl")
+include("variants/CPC_SRKE_bT.jl")
+
+

--- a/src/models/CPC/chainmodel/Elliott.jl
+++ b/src/models/CPC/chainmodel/Elliott.jl
@@ -1,0 +1,32 @@
+struct ElliottRDF <: CPCRDFModel
+end
+
+"""
+    ElliottRDF <: CPCRDFModel
+    ElliottRDF()
+
+## Input parameters
+
+None
+
+## Description
+
+Elliott Radial distance function.
+```
+    g_rdf(::ElliottRDF,β) = 1/(1 - 0.475*β)
+```
+"""
+ElliottRDF
+
+export ElliottRDF
+function ElliottRDF(components::Array{String,1}; userlocations::Array{String,1}=String[], verbose=false)
+    return ElliottRDF()
+end
+
+function ElliottRDF(; userlocations::Array{String,1}=String[], verbose=false)
+    return ElliottRDF()
+end
+
+is_splittable(::ElliottRDF) = false
+
+g_rdf(::ElliottRDF,β) = 1/(1 - 0.475*β)

--- a/src/models/CPC/chainmodel/chainmodel.jl
+++ b/src/models/CPC/chainmodel/chainmodel.jl
@@ -1,0 +1,2 @@
+include("Elliott.jl")
+

--- a/src/models/CPC/cubicmodel/cubicmodel.jl
+++ b/src/models/CPC/cubicmodel/cubicmodel.jl
@@ -1,0 +1,68 @@
+abstract type CPCRuleModel <: MixingRule end
+
+function omega_fit(Tc,Pc,m,Δ1,Δ2,g)
+    #http://dx.doi.org/10.1021/acs.iecr.9b00436
+    #supplementary information
+    #should work with any cubic EoS with constant Δ1,Δ2 at the moment
+    δ1,δ2 = -Δ1,-Δ2
+    function ∂lng∂β(β)
+        _g,_∂g = Solvers.f∂f(g,β)
+        return _∂g/_g
+    end
+
+    function f0(β)
+        ∂1lng, ∂2lng, ∂3lng = Solvers.f∂f∂2f(∂lng∂β,β)
+        mdm = ((1-m)/m)
+        k1 = 2*(2*β - 1)/(1 - β)^3
+        k2 = mdm*(β*β*∂2lng + 2*β*∂1lng + 1) + 1/(1 - β)^2
+        f0 = (1 + δ1*β)*(1 + δ2*β)
+        f1 = β/f0
+        f2 = (1 - δ1*δ2*β*β)/(f0*f0)
+        f3 = (β*(δ1*δ2*β)^2 - 3*δ1*δ2*β - δ1 - δ2)/(f0*f0*f0)
+        k3 = 2/(β*f2 + f1)
+        k4 = (β*β*f3 - f1)
+        k5 = mdm*(β*β*β*∂3lng + 2*β*β*∂2lng - 2*β*∂1lng - 2)
+        return k1 - k2*k3*k4 + k5
+    end
+
+    prob = Roots.ZeroProblem(f0,0.5) #TODO, look for better initial point
+    βc = Roots.solve(prob)
+    f0 = (1 + δ1*βc)*(1 + δ2*βc)
+    f1 = βc/f0
+    f2 = (1 - δ1*δ2*βc*βc)/(f0*f0)
+    f3 = (βc*(δ1*δ2*βc)^2 - 3*δ1*δ2*βc - δ1 - δ2)/(f0*f0*f0)
+
+    ∂1lng, ∂2lng, ∂3lng = Solvers.f∂f∂2f(∂lng∂β,βc)
+    λmon = - f1 + (1 - βc)*(βc*f2 + f1)
+    λchain = 1 + βc*∂1lng + (1 - βc)*(-βc*βc*∂2lng - 2*βc*∂lng - 1)
+    Zc_mon = 1/((1 - βc)*(1 + f1/λmon))
+    Zc_chain = (f1*λchain/λmon + 1 + βc*∂1lng)/(1 + f1/λmon)
+    Zc = m*Zc_mon + (1 - m)*Zc_chain
+    Ωa = (1/m^2)*(βc*Zc*Zc/λmon + (m - 1)*βc*Zc*λchain/λmon)
+    Ωb = βc*Zc/m
+    return Ωa,Ωb
+end
+
+function ab_premixing(::Type{AB},mixing::CPCRuleModel,Tc,pc,kij) where AB <: <:ABCubicModel
+    Ωa, Ωb = ab_consts(AB)
+    components = pc.components
+    n = length(components)
+    m = mixing.params.segment
+    omega_a = mixing.params.omega_a
+    omega_b = mixing.params.omega_b
+    g(β) = g_rdf(mixing.rdf,β)
+    for i in 1:n
+        Ωa,Ωb = omega_fit(Tc[i],Pc[i],m,Δ1,Δ2,g)
+        omega_a[i] = Ωa
+        omega_b[i] = Ωb
+    end
+    ai = omega_a .* R̄^2*Tc^2/pc
+    bi = omega_b*R̄*Tc/pc
+
+    a = epsilon_LorentzBerthelot(SingleParam("a",components,ai),kij)
+    b = sigma_LorentzBerthelot(SingleParam("b",components,bi))
+    return a,b
+end
+
+
+include("mixing/CPCRule.jl")

--- a/src/models/CPC/cubicmodel/mixing/CPCRule.jl
+++ b/src/models/CPC/cubicmodel/mixing/CPCRule.jl
@@ -1,0 +1,83 @@
+
+struct CPCRuleParam  <: EoSParam
+    segment::SingleParam{Float64}
+    omega_a::SingleParam{Float64}
+    omega_b::SingleParam{Float64}
+end
+
+struct CPCRule{R} <: CPCRuleModel
+    components::Vector{String}
+    params::CPCRuleParam
+    rdf::R
+    references::Vector{String}
+end
+
+@registermodel CPCRule
+
+"""
+    CPCRule <: CPCRuleModel
+    
+    CPCRule(components::Vector{String};
+    userlocations::Vector{String}=String[],
+    rdf = ElliottRDF()
+    verbose::Bool=false)
+
+## Input Parameters
+
+None
+
+## Input models 
+
+- `rdf`: CPC' Radial distance function model
+
+## Description
+
+Mixing Rule used by Cubic plus Chain equation of state.
+```
+aᵢⱼ = √(aᵢaⱼ)(1-kᵢⱼ)
+bᵢⱼ = (bᵢ + bⱼ)/2
+m̄b̄ = ∑bᵢxᵢmᵢ
+m̄²ā = ∑aᵢⱼxᵢxⱼmᵢmⱼ
+c̄ = ∑cᵢxᵢ
+```
+"""
+CPCRule
+export CPCRule
+function CPCRule(components::Vector{String}; userlocations::Vector{String}=String[],rdf = ElliottRDF(), verbose::Bool=false)
+    params = getparams(components,["todo"])
+    segment = params["m"]
+    references = ["10.1021/acs.iecr.9b00435"]
+    omega_a = SingleParam("Ωa",components)
+    omega_b = SingleParam("Ωb",components)
+    params = CPCRuleParam(segment,omega_a,omega_b)
+    model = CPCRule(components, params, rdf, references)
+    return model
+end
+
+
+
+function mixing_rule(model::ABCubicModel,V,T,z,mixing_model::CPCRuleModel,α,a,b,c)
+    n = sum(z)
+    invn = (one(n)/n)
+    invn2 = invn^2
+    m = mixing_model.params.segment
+    invn = (one(n)/n)
+    invn2 = invn^2
+    #b̄ = dot(z,Symmetric(b),z) * invn2
+    ā,b̄ = zero(T+first(z)),zero(first(z))
+    m̄,c̄ = dot(m,z)*invn,dot(z,c)*invn
+    for i in 1:length(z)
+        zi,αi,mi = z[i],α[i],m[i]
+        zi2 = zi^2
+        b̄ += mi*b[i,i]*zi2
+        ā += mi*mia[i,i]*αi*zi^2
+        for j in 1:(i-1)
+            zij = zi*z[j]
+            ā += 2*mi*m[j]*a[i,j]*sqrt(αi*α[j])*zij
+        end
+    end
+    ā *= invn2/(m̄*m̄)
+    b̄ *= invn2/m̄
+    #dot(z,Symmetric(a .* sqrt.(α*α')),z) * invn2
+    return ā,b̄,c̄
+end

--- a/src/models/CPC/variants/CPC_RKE.jl
+++ b/src/models/CPC/variants/CPC_RKE.jl
@@ -1,0 +1,30 @@
+function CPC_RKE(components::Vector{String}; 
+    idealmodel=BasicIdeal,
+    cubicmodel = RK,
+    alpha = RKAlpha,
+    mixing = CPCRule,
+    rdf = ElliottRDF,
+    translation=NoTranslation,
+    userlocations=String[], 
+    ideal_userlocations=String[],
+    alpha_userlocations = String[],
+    mixing_userlocations = String[],
+    rdf_userlocations = String[],
+    translation_userlocations = String[],
+    verbose=false)
+
+    return CubicPlusChain(components; 
+    idealmodel,
+    cubicmodel,
+    alpha,
+    mixing,
+    rdf,
+    translation,
+    userlocations, 
+    ideal_userlocations,
+    alpha_userlocations,
+    mixing_userlocations,
+    rdf_userlocations,
+    translation_userlocations,
+    verbose)
+end 

--- a/src/models/CPC/variants/CPC_SRKE.jl
+++ b/src/models/CPC/variants/CPC_SRKE.jl
@@ -1,0 +1,30 @@
+function CPC_SRKE(components::Vector{String}; 
+    idealmodel=BasicIdeal,
+    cubicmodel = RK,
+    alpha = SoaveAlpha,
+    mixing = CPCRule,
+    rdf = ElliottRDF,
+    translation=NoTranslation,
+    userlocations=String[], 
+    ideal_userlocations=String[],
+    alpha_userlocations = String[],
+    mixing_userlocations = String[],
+    rdf_userlocations = String[],
+    translation_userlocations = String[],
+    verbose=false)
+
+    return CubicPlusChain(components; 
+    idealmodel,
+    cubicmodel,
+    alpha,
+    mixing,
+    rdf,
+    translation,
+    userlocations, 
+    ideal_userlocations,
+    alpha_userlocations,
+    mixing_userlocations,
+    rdf_userlocations,
+    translation_userlocations,
+    verbose)
+end


### PR DESCRIPTION
fixes #93. it uses the algorithm described in 10.1021/acs.iecr.9b00436 (supplementary information) to be generic respect to cubic EoS and RDF contribution.
TODO:
 - plug databases
 - the original procedure for calculating Ωa and Ωb does not account for a variable β(T). look how to incorporate those.