### PR TITLE
allow passing a `NamedTuple` to userlocations kwarg

### DIFF
--- a/src/database/ParamOptions.jl
+++ b/src/database/ParamOptions.jl
@@ -10,8 +10,8 @@ const IGNORE_HEADERS = ["dipprnumber", "smiles", "cas"]
 """
     ParamOptions(;kwargs...)
 Struct containing all the options related to parameter parsing:
-* `userlocations::Vector{String} = String[]`: List of used-defined locations to search.
-* `group_userlocations::Vector{String} = String[]`: List of used-defined group locations to search.
+* `userlocations = String[]`: List of used-defined locations to search.
+* `group_userlocations = String[]`: List of used-defined group locations to search.
 * `asymmetricparams::Vector{String} = String[]`: List of pair parameters that follow that `param[i,j] ≠ param[j,i]`. if not set on asymmetric pairs, the asymmetric values will be overwritten!
 * `ignore_headers::Vector{String} =  ["dipprnumber", "smiles"]`: List of ignored headers.
 * `ignore_missing_singleparams::Vector{String} = String[]`: List of parameters where checking for missing parameter values (in `SingleParam`) or the diagonal (on `PairParam`) are ignored.
@@ -24,9 +24,9 @@ Struct containing all the options related to parameter parsing:
 * `return_sites::Bool = true`: If set to false, association params will be ignored and sites will not be created, even if they exist in the list of locations.
 * `component_delimiter::String = "~|~"`: When there are multiple component names to match, seperate them by this delimiter.
 """
-Base.@kwdef struct ParamOptions
-    userlocations::Vector{String} = String[]
-    group_userlocations::Vector{String} = String[]
+Base.@kwdef struct ParamOptions{𝕌,𝔾}
+    userlocations::𝕌 = String[]
+    group_userlocations::𝔾 = String[]
     asymmetricparams::Vector{String}= String[]
     ignore_missing_singleparams::Vector{String} = String[]
     ignore_headers::Vector{String} = IGNORE_HEADERS

--- a/src/database/UserReader.jl
+++ b/src/database/UserReader.jl
@@ -13,7 +13,7 @@ end
     ParamTable(type::Symbol,table;
     location = nothing,
     name = nothing,
-    grouptype = :unkwown,
+    grouptype = :unknown,
     options = ParamOptions())
 
 Creates a clapeyron CSV file and returns the location of that file. the type determines the table type:

--- a/src/database/database.jl
+++ b/src/database/database.jl
@@ -335,6 +335,11 @@ function createparams(components::Vector{String},
         merge_allparams!(allparams,allnotfoundparams,foundparams,notfoundparams,false)
     end
 
+    #clean not found params.
+    for (kk,vv) ∈ allparams
+        delete!(allnotfoundparams,kk)
+    end
+
     return allparams,allnotfoundparams
 end
 #helper function, merges params into the main list

--- a/src/database/database.jl
+++ b/src/database/database.jl
@@ -172,7 +172,7 @@ Note, that the parser will not fail if you pass different parameters with differ
 """
 function getparams(components,
                     locations::Array{String,1}=String[];
-                    userlocations::Vector{String}=String[],
+                    userlocations=String[],
                     asymmetricparams::Vector{String}=String[],
                     ignore_missing_singleparams::Vector{String}=String[],
                     ignore_headers::Vector{String} =  IGNORE_HEADERS,
@@ -301,6 +301,7 @@ function createparams(components::Vector{String},
 
     allparams = Dict{String,RawParam}()
     allnotfoundparams = Dict{String,CSVType}()
+    
     for filepath ∈ filepaths
         
         _replace = startswith(filepath,"@REPLACE")
@@ -352,6 +353,10 @@ function createparams(components::Vector{String},
                 delete!(allparams,kk)
             end
         end
+    end
+
+    if param.userlocations isa NamedTuple
+        println("here")
     end
     #delete all found params from allnotfoundparams
     for (kk,vv) ∈ allparams

--- a/src/database/database.jl
+++ b/src/database/database.jl
@@ -620,6 +620,18 @@ function findparamsinnt(components,
         elseif v isa Matrix && parsegroups == :off
             param = RawParam(ks,nothing,vec(v),nothing,nothing,pairdata,:unknown)
             push!(foundvalues,param)
+        elseif v isa Dict{Tuple{Tuple{String,String},Tuple{String,String}}}
+            param = RawParam(ks,Vector{NTuple{4,String}}(undef,0),Vector{valtype(v)}(undef,0),String[],String[],assocdata,:unknown)
+            empty_string = ""
+            for (k_dict,v_dict) in pairs(v)
+                sp1,s1 = first(k_dict)
+                sp2,s2 = last(k_dict)
+                push!(param.component_info,(sp1,sp2,s1,s2))
+                push!(param.data,v_dict)
+                push!(param.sources,empty_string)
+                push!(param.csv,empty_string)
+                push!(foundvalues,param)
+            end
         else
             throw(error("cannot parse combination key = $k, value = $v as a valid parameter."))
         end

--- a/src/database/database.jl
+++ b/src/database/database.jl
@@ -622,17 +622,17 @@ function findparamsinnt(components,
     for (k,v) in pairs(nt)
         ks = string(k)
         if k == :groups && parsegroups == :groups
-            param = RawParam(ks,components,v,nothing,nothing,groupdata,:unknown)
+            param = RawParam(ks,nothing,v,nothing,nothing,groupdata,:unknown)
             push!(foundvalues,param)
         elseif k == :intragroups && parsegroups == :structgroups
-            param = RawParam(ks,components,v,nothing,nothing,structgroupdata,:unknown)
+            param = RawParam(ks,nothing,v,nothing,nothing,structgroupdata,:unknown)
         elseif (k == :epsilon_assoc || k == :bondvol) && parsegroups == :off && v === nothing
             notfoundvalues[ks] = assocdata
         elseif v isa Vector && parsegroups == :off
-            param = RawParam(ks,components,v,nothing,nothing,singledata,:unknown)
+            param = RawParam(ks,nothing,v,nothing,nothing,singledata,:unknown)
             push!(foundvalues,param)
         elseif v isa Matrix && parsegroups == :off
-            param = RawParam(ks,components,vec(v),nothing,nothing,pairdata,:unknown)
+            param = RawParam(ks,nothing,vec(v),nothing,nothing,pairdata,:unknown)
             push!(foundvalues,param)
         else
             throw(error("cannot parse combination key = $k, value = $v as a valid parameter."))

--- a/src/database/database_group.jl
+++ b/src/database/database_group.jl
@@ -1,5 +1,5 @@
 function fast_parse_grouptype(filepaths::Vector{String})
-    #only parses grouptype, if present in any CSV, is used. if not, return unkwown
+    #only parses grouptype, if present in any CSV, is used. if not, return unknown
     grouptype = :not_set
    
     for filepath ∈ filepaths
@@ -13,13 +13,13 @@ function fast_parse_grouptype(filepaths::Vector{String})
             grouptype = new_grouptype
         else
             if grouptype !== new_grouptype
-                if new_grouptype != :unkwown #for backwards compatibility
+                if new_grouptype != :unknown #for backwards compatibility
                     error_different_grouptype(grouptype,new_grouptype)
                 end
             end
         end
     end
-    grouptype == :not_set && (grouptype = :unkwown)
+    grouptype == :not_set && (grouptype = :unknown)
     return grouptype
 
 end

--- a/src/database/database_group.jl
+++ b/src/database/database_group.jl
@@ -75,8 +75,8 @@ gc_get_group(x) = last(x)
 
 
 function GroupParam(gccomponents::Vector,
-    group_locations::Vector{String}=String[];
-    group_userlocations::Vector{String}=String[],
+    group_locations=String[];
+    group_userlocations=String[],
     verbose::Bool = false,
     grouptype = :unknown)
     options = ParamOptions(;group_userlocations,verbose)

--- a/src/database/database_group.jl
+++ b/src/database/database_group.jl
@@ -84,7 +84,7 @@ function GroupParam(gccomponents::Vector,
 end
 
 function GroupParam(gccomponents,
-    grouplocations::Array{String,1}=String[],
+    grouplocations=String[],
     options::ParamOptions = DefaultOptions,
     grouptype = :unknown)
 

--- a/src/database/database_rawparam.jl
+++ b/src/database/database_rawparam.jl
@@ -10,7 +10,7 @@ For Clapeyron 0.4.0, this will also hold the group type, tapes with different gr
 =#
 struct RawParam{T}
     name::String
-    component_info::Union{Vector{NTuple{4,String}},Vector{String}}  # "Tape" for component data (component1,component2,site1,site2)
+    component_info::Union{Vector{NTuple{4,String}},Nothing}  # "Tape" for component data (component1,component2,site1,site2)
     data::Vector{T} # "Tape" of data
     sources::Union{Vector{String},Nothing} # "Tape" of parsed sources
     csv::Union{Vector{String},Nothing} # "Tape" of origin csv
@@ -145,16 +145,13 @@ end
 
 function compile_single(name,components,raw::RawParam,options)
     
-    if eltype(raw.component_info) == String
+    if eltype(raw.component_info) == String #build from named tuple
         return SingleParam(raw.name,components,raw.data)
     end
 
     EMPTY_STR = ""
     l = length(components)
     L = eltype(raw)
-    
-
-    
     if L <: Number
         values = zeros(L,l)
     else
@@ -187,7 +184,7 @@ end
 
 function compile_pair(name,components,raw::RawParam,options)
     
-    if eltype(raw.component_info) == String
+    if eltype(raw.component_info) == String #build from named tuple
         l = length(components)
         return PairParam(raw.name,components,reshape(raw.data,(l,l)))
     end

--- a/src/database/database_rawparam.jl
+++ b/src/database/database_rawparam.jl
@@ -145,7 +145,7 @@ end
 
 function compile_single(name,components,raw::RawParam,options)
     
-    if eltype(raw.component_info) == String #build from named tuple
+    if isnothing(raw.component_info) #build from named tuple
         return SingleParam(raw.name,components,raw.data)
     end
 
@@ -184,7 +184,7 @@ end
 
 function compile_pair(name,components,raw::RawParam,options)
     
-    if eltype(raw.component_info) == String #build from named tuple
+    if isnothing(raw.component_info) #build from named tuple
         l = length(components)
         return PairParam(raw.name,components,reshape(raw.data,(l,l)))
     end

--- a/src/database/database_rawparam.jl
+++ b/src/database/database_rawparam.jl
@@ -10,10 +10,10 @@ For Clapeyron 0.4.0, this will also hold the group type, tapes with different gr
 =#
 struct RawParam{T}
     name::String
-    component_info::Vector{NTuple{4,String}}  # "Tape" for component data (component1,component2,site1,site2)
+    component_info::Union{Vector{NTuple{4,String}},Vector{String}}  # "Tape" for component data (component1,component2,site1,site2)
     data::Vector{T} # "Tape" of data
-    sources::Vector{String} # "Tape" of parsed sources
-    csv::Vector{String} # "Tape" of origin csv
+    sources::Union{Vector{String},Nothing} # "Tape" of parsed sources
+    csv::Union{Vector{String},Nothing} # "Tape" of origin csv
     type::CSVType #the type of data
     grouptype::Symbol #in the future, this could hold an "Options" type,generated per CSV
 end
@@ -122,7 +122,7 @@ it also builds empty params, if you pass a CSVType instead of a RawParam
 Base.@nospecialize
 
 function compile_param(components,name,raw::RawParam,site_strings,options)
-    if raw.type == singledata || raw.type == groupdata || raw.type == intragroupdata
+    if raw.type == singledata || raw.type == groupdata || raw.type == structgroupdata
         return compile_single(name,components,raw,options)
     elseif raw.type == pairdata
         return compile_pair(name,components,raw,options)
@@ -144,9 +144,17 @@ function compile_param(components,name,raw::CSVType,site_strings,options)
 end
 
 function compile_single(name,components,raw::RawParam,options)
+    
+    if eltype(raw.component_info) == String
+        return SingleParam(raw.name,components,raw.data)
+    end
+
     EMPTY_STR = ""
     l = length(components)
     L = eltype(raw)
+    
+
+    
     if L <: Number
         values = zeros(L,l)
     else
@@ -178,6 +186,12 @@ function compile_single(name,components,type::CSVType,options)
 end
 
 function compile_pair(name,components,raw::RawParam,options)
+    
+    if eltype(raw.component_info) == String
+        l = length(components)
+        return PairParam(raw.name,components,reshape(raw.data,(l,l)))
+    end
+    
     EMPTY_STR = ""
     symmetric = name ∉ options.asymmetricparams
     l = length(components)

--- a/src/database/database_utils.jl
+++ b/src/database/database_utils.jl
@@ -91,7 +91,7 @@ function _getpaths(location,special_parse = true)
     return files
 end
 
-function flattenfilepaths(locations,userlocations)
+function flattenfilepaths(locations,userlocations::Vector{String})
     defaultpaths = reduce(vcat,getpaths.(locations; relativetodatabase=true),init = String[])
     userpaths = reduce(vcat,getpaths.(userlocations),init = String[])
     idx = findfirst(isequal("@REMOVEDEFAULTS"),userpaths)
@@ -101,6 +101,11 @@ function flattenfilepaths(locations,userlocations)
     end
     return vcat(defaultpaths,userpaths,String[])
 end
+Base.@nospecialize
+function flattenfilepaths(locations,userlocations::NamedTuple)
+    return String[]
+end
+Base.@specialize
 
 function getline(filepath::AbstractString, selectedline::Int)
     is_inline_csv(filepath) && return getline(IOBuffer(filepath),selectedline)
@@ -157,6 +162,7 @@ function _indexin(query,list,separator,indices)
     end
     return res,comp_res
 end
+
 else
     function _indexin(query,list,separator,indices)
         kq = keys(query)

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -17,7 +17,7 @@ julia> grouplist = [
            ("nonadecanol", ["CH3"=>1, "CH2"=>18, "OH"=>1]),
            ("ibuprofen", ["CH3"=>3, "COOH"=>1, "aCCH"=>1, "aCCH2"=>1, "aCH"=>4])];
 julia> groups = GroupParam(grouplist)
-GroupParam(:unkwown) with 3 components:
+GroupParam(:unknown) with 3 components:
  "ethanol": "CH3" => 1, "CH2" => 1, "OH" => 1
  "nonadecanol": "CH3" => 1, "CH2" => 18, "OH" => 1
  "ibuprofen": "CH3" => 3, "COOH" => 1, "aCCH" => 1, "aCCH2" => 1, "aCH" => 4

--- a/src/database/params/PairParam.jl
+++ b/src/database/params/PairParam.jl
@@ -95,6 +95,7 @@ Base.eltype(param::PairParameter{T}) where T = T
 
 #unsafe constructor
 function PairParam(name,components,values)
+    @assert length(components) == LinearAlgebra.checksquare(values)
     missingvals = fill(false,size(values))
     src = String[]
     sourcecsv = String[]
@@ -102,12 +103,13 @@ function PairParam(name,components,values)
 end
 
 function PairParam(name::String,
-                    components::Array{String,1},
-                    values::Array{T,2},
-                    ismissingvalues = fill(false,length(components),length(components)),
-                    sourcecsvs::Array{String,1} = String[], 
-                    sources::Array{String,1} = String[]) where T
+    components::Array{String,1},
+    values::Array{T,2},
+    ismissingvalues = fill(false,length(components),length(components)),
+    sourcecsvs::Array{String,1} = String[], 
+    sources::Array{String,1} = String[]) where T
     
+    @assert length(components) == LinearAlgebra.checksquare(values)
     _values,_ismissingvalues = defaultmissing(values)
     if !all(ismissingvalues)
         _ismissingvalues = ismissingvalues
@@ -121,12 +123,13 @@ function PairParam(name::String,
     ismissingvalues = map(!,diagm(fill(true,length(components)))),
     sourcecsvs::Array{String,1} = String[], 
     sources::Array{String,1} = String[]) where T
-
-_values,_ismissingvalues = defaultmissing(diagm(values))
-if !all(ismissingvalues)
-_ismissingvalues = ismissingvalues
-end
-return PairParameter(name, components,_values, _ismissingvalues, sourcecsvs, sources)
+    
+    @assert length(components) == length(values)
+    _values,_ismissingvalues = defaultmissing(diagm(values))
+    if !all(ismissingvalues)
+        _ismissingvalues = ismissingvalues
+    end
+    return PairParameter(name, components,_values, _ismissingvalues, sourcecsvs, sources)
 end
 
 # If no value is provided, just initialise empty param.

--- a/src/database/params/SingleParam.jl
+++ b/src/database/params/SingleParam.jl
@@ -83,8 +83,10 @@ Base.eltype(param::SingleParameter{T}) where T = T
 LinearAlgebra.dot(param::SingleParameter,x::Union{<:AbstractVector,<:Number}) = dot(param.values,x)
 LinearAlgebra.dot(x::Union{<:AbstractVector,<:Number},param::SingleParameter) = dot(x,param.values)
 
-SingleParam(name,components,values,missingvals,src,sourcecsv) = SingleParameter(name,components,values,missingvals,src,sourcecsv)
-
+function SingleParam(name,components,values,missingvals,src,sourcecsv) 
+    @assert length(components) == length(values)
+    SingleParameter(name,components,values,missingvals,src,sourcecsv)
+end
 
 function Base.show(io::IO, ::MIME"text/plain", param::SingleParameter)
     len = length(param.values)
@@ -126,6 +128,7 @@ function SingleParam(
         sourcecsvs = String[],
         sources = String[]
     ) where T
+    @assert length(components) == length(values)
     if any(ismissing, values)
         _values,_ismissingvalues = defaultmissing(values)
         TT = eltype(_values)
@@ -142,14 +145,15 @@ function SingleParam(
         name::String,
         components::Vector{String};
         sources = String[]
-    ) 
+    )
     values = fill(0.0, length(components))
     return SingleParam(name, components, values, String[], sources)
 end
 
-function SingleParam(x::SingleParameter, v::Vector)
+function SingleParam(oldparam::SingleParameter, v::Vector)
     _values,_ismissingvalues = defaultmissing(v)
-    return SingleParam(x.name, x.components,_values, _ismissingvalues , x.sourcecsvs, x.sources)
+    @assert length(oldparam.components) == length(_values)
+    return SingleParam(oldparam.name, oldparam.components,_values, _ismissingvalues , oldparam.sourcecsvs, oldparam.sources)
 end
 
 #convert utilities
@@ -207,7 +211,7 @@ function pack_vectors(params::Vararg{SingleParameter{T},N}) where {T<:Number,N}
     SingleParam(name,components,vals,missingvals,srccsv,src)
 end
 
-#= Operations 
+#= Operations
 function Base.:(+)(param::SingleParameter, x::Number)
     values = param.values .+ x
     return SingleParam(param.name, param.components, values, param.ismissingvalues, param.sourcecsvs, param.sources)

--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -32,7 +32,7 @@ end
 
 Returns an initial guess of the volume at a pressure, temperature, composition and suggested phase.
 
-If the suggested phase is `:unkwown` or `:liquid`, calls [`x0_volume_liquid`](@ref).
+If the suggested phase is `:unknown` or `:liquid`, calls [`x0_volume_liquid`](@ref).
 
 If the suggested phase is `:gas`, calls [`x0_volume_gas`](@ref).
 

--- a/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
@@ -9,7 +9,7 @@ end
 
 @newmodelsimple COSTALD COSTALDModel COSTALDParam
 
-function COSTALD(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function COSTALD(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     Tc = params["Tc"]
     Vc = params["Vc"]

--- a/src/models/CompositeModel/LiquidVolumeModel/DIPPR105Liquid/DIPPR105Liquid.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/DIPPR105Liquid/DIPPR105Liquid.jl
@@ -12,7 +12,7 @@ end
 
 @newmodelsimple DIPPR105Liquid DIPPR105LiquidModel DIPPR105LiquidParam
 
-function DIPPR105Liquid(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function DIPPR105Liquid(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["Correlations/volume_correlations/dippr105_like.csv"]; userlocations=userlocations, verbose=verbose)
     A = params["A"]
     B = params["B"]

--- a/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
@@ -9,7 +9,7 @@ end
 
 @newmodelsimple RackettLiquid RackettLiquidModel RackettLiquidParam
 
-function RackettLiquid(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function RackettLiquid(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]
@@ -72,7 +72,7 @@ function volume_impl(model::RackettLiquidModel,p,T,z::SingleComp,phase=:unknown,
 end
 
 
-function YamadaGunnLiquid(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function YamadaGunnLiquid(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]

--- a/src/models/CompositeModel/SaturationModel/DIPPR101Sat/DIPPR101Sat.jl
+++ b/src/models/CompositeModel/SaturationModel/DIPPR101Sat/DIPPR101Sat.jl
@@ -18,7 +18,7 @@ end
     DIPPR101Sat <: SaturationModel
     
     DIPPR101Sat(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -58,7 +58,7 @@ psat(T) = exp(A + B/T + C•log(T) + D•T^E)
 """
 DIPPR101Sat
 
-function DIPPR101Sat(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function DIPPR101Sat(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv","Correlations/saturation_correlations/dippr101_like.csv"]; userlocations=userlocations, verbose=verbose)
     Tc = params["Tc"]
     Pc = params["Pc"]

--- a/src/models/CompositeModel/SaturationModel/LeeKeslerSat/LeeKeslerSat.jl
+++ b/src/models/CompositeModel/SaturationModel/LeeKeslerSat/LeeKeslerSat.jl
@@ -12,7 +12,7 @@ end
     LeeKeslerSat <: SaturationModel
     
     LeeKeslerSat(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -37,7 +37,7 @@ f₁ = 15.2518 - 15.6875/Tr - 13.4721•log(Tr) + 0.43577•Tr⁶
 """
 LeeKeslerSat
 
-function LeeKeslerSat(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function LeeKeslerSat(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     acentricfactor = params["acentricfactor"]
     Tc = params["Tc"]

--- a/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
+++ b/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
@@ -164,29 +164,29 @@ function ζ0123(model::SAFTVRMieModel, V, T, z,_d=@f(d),m̄ = dot(z,model.params
 end
 
 
+function d_vrmie(T,λa,λr,σ,ϵ,u = SAFTVRMieconsts.u,v = SAFTVRMieconsts.v)
+    θ = Cλ_mie(λa, λr)*ϵ/T
+    di = zero(T*1.0)
+    λrinv = 1/λr
+    λaλr = λa/λr
+    for j ∈ 1:5
+        θj = (θ/(θ+u[j]))
+        di += w[j] * θj^(1/λr + 1) * exp(θ*(θj^(-λa/λr)-1)) / (θ*λr)
+    end
+    return σ*(1-di)
+end
+
 function d(model::SAFTVRMieModel, V, T, z)
-    _ϵ = diagvalues(model.params.epsilon)
-    _σ = diagvalues(model.params.sigma)
-    _λa = diagvalues(model.params.lambda_a)
-    _λr = diagvalues(model.params.lambda_r)
+    ϵ = diagvalues(model.params.epsilon)
+    σ = diagvalues(model.params.sigma)
+    λa = diagvalues(model.params.lambda_a)
+    λr = diagvalues(model.params.lambda_r)
     u = SAFTVRMieconsts.u
     w = SAFTVRMieconsts.w
-    _0 = zero(T*1.0)
     n = length(z)
-    _d = zeros(typeof(_0),n)
+    _d = fill(zero(T*1.0),n)
     for k ∈ 1:n
-        ϵ = _ϵ[k]
-        σ = _σ[k]
-        λa = _λa[k]
-        λr = _λr[k]
-        θ = Cλ(model,V,T,z,λa,λr)*ϵ/T
-        di = _0
-        λrinv = 1/λr
-        λaλr = λa/λr
-        for j ∈ 1:5
-            di += w[j]*(θ/(θ+u[j]))^λrinv*(exp(θ*(1/(θ/(θ+u[j]))^λaλr-1))/(u[j]+θ)/λr)
-        end
-        _d[k] = σ*(1-di)
+        _d[k] = d_vrmie(T,λa[k],λr[k],σ[k],ϵ[k],u,v)
     end
     return _d
 end
@@ -201,8 +201,10 @@ end
 
 
 function Cλ(model::SAFTVRMieModel, V, T, z, λa, λr)
-    return (λr/(λr-λa))*(λr/λa)^(λa/(λr-λa))
+    return Cλ_mie(λa, λr)
 end
+
+Cλ_mie(λa, λr) = (λr/(λr-λa))*(λr/λa)^(λa/(λr-λa))
 
 function ζ_X(model::SAFTVRMieModel, V, T, z,_d = @f(d))
     _ζ_X,σ3x = @f(ζ_X_σ3,_d)
@@ -747,22 +749,11 @@ Optimizations for single component SAFTVRMie
 #######
 
 function d(model::SAFTVRMie, V, T, z::SingleComp)
-    _ϵ = model.params.epsilon
-    _σ = model.params.sigma
-    _λa = model.params.lambda_a
-    _λr = model.params.lambda_r
+    ϵ = model.params.epsilon
+    σ = model.params.sigma
+    λa = model.params.lambda_a
+    λr = model.params.lambda_r
     u = SAFTVRMieconsts.u
     w = SAFTVRMieconsts.w
-    ϵ = _ϵ[1]
-    σ = _σ[1]
-    λa = _λa[1]
-    λr = _λr[1]
-    θ = Cλ(model,V,T,z,λa,λr)*ϵ/T
-    λrinv = 1/λr
-    λaλr = λa/λr
-    di = zero(T*1.0)
-    for j ∈ 1:5
-        di += w[j]*(θ/(θ+u[j]))^λrinv*(exp(θ*(1/(θ/(θ+u[j]))^λaλr-1))/(u[j]+θ)/λr)
-    end
-    return SA[σ*(1-di)]
+    return SA[d_vrmie(T,λa[1],λr[1],σ[1],ϵ[1],u,v)]
 end

--- a/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
+++ b/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
@@ -164,7 +164,7 @@ function ζ0123(model::SAFTVRMieModel, V, T, z,_d=@f(d),m̄ = dot(z,model.params
 end
 
 
-function d_vrmie(T,λa,λr,σ,ϵ,u = SAFTVRMieconsts.u,v = SAFTVRMieconsts.v)
+function d_vrmie(T,λa,λr,σ,ϵ,u = SAFTVRMieconsts.u,w = SAFTVRMieconsts.w)
     θ = Cλ_mie(λa, λr)*ϵ/T
     di = zero(T*1.0)
     λrinv = 1/λr
@@ -186,19 +186,15 @@ function d(model::SAFTVRMieModel, V, T, z)
     n = length(z)
     _d = fill(zero(T*1.0),n)
     for k ∈ 1:n
-        _d[k] = d_vrmie(T,λa[k],λr[k],σ[k],ϵ[k],u,v)
+        _d[k] = d_vrmie(T,λa[k],λr[k],σ[k],ϵ[k],u,w)
     end
     return _d
 end
 
 
 function d(model::SAFTVRMieModel, V, T, z, λa,λr,ϵ,σ)
-    u = SAFTVRMieconsts.u
-    w = SAFTVRMieconsts.w
-    θ = @f(Cλ,λa,λr)*ϵ/T
-    σ*(1-∑(w[j]*(θ/(θ+u[j]))^(1/λr)*(exp(θ*(1/(θ/(θ+u[j]))^(λa/λr)-1))/(u[j]+θ)/λr) for j ∈ 1:5))
+    d_vrmie(T,λa,λr,σ,ϵ,SAFTVRMieconsts.u,SAFTVRMieconsts.w)
 end
-
 
 function Cλ(model::SAFTVRMieModel, V, T, z, λa, λr)
     return Cλ_mie(λa, λr)
@@ -755,5 +751,5 @@ function d(model::SAFTVRMie, V, T, z::SingleComp)
     λr = model.params.lambda_r
     u = SAFTVRMieconsts.u
     w = SAFTVRMieconsts.w
-    return SA[d_vrmie(T,λa[1],λr[1],σ[1],ϵ[1],u,v)]
+    return SA[d_vrmie(T,λa[1],λr[1],σ[1],ϵ[1],u,w)]
 end

--- a/src/models/cubic/PR/PR.jl
+++ b/src/models/cubic/PR/PR.jl
@@ -63,7 +63,7 @@ export PR
 function PR(components::Vector{String}; idealmodel=BasicIdeal,
     alpha = PRAlpha,
     mixing = vdW1fRule,
-    activity=nothing,
+    activity = nothing,
     translation=NoTranslation,
     userlocations=String[], 
     ideal_userlocations=String[],

--- a/src/models/cubic/alphas/BM.jl
+++ b/src/models/cubic/alphas/BM.jl
@@ -11,7 +11,7 @@ export BMAlpha
     BMAlpha <: BMAlphaModel
 
     MTAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -43,7 +43,7 @@ for RK models:
 """
 BMAlpha
 
-function BMAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function BMAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = BMAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/CPAAlpha.jl
+++ b/src/models/cubic/alphas/CPAAlpha.jl
@@ -11,7 +11,7 @@ export CPAAlpha
     CPAAlpha <: CPAAlphaModel
     
     CPAAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -29,7 +29,7 @@ Cubic alpha `(α(T))` model. Default for `CPA` EoS.
 """
 CPAAlpha
 
-function CPAAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false, kwargs...)
+function CPAAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false, kwargs...)
     params = getparams(components, ["SAFT/CPA/CPA_like.csv"]; userlocations=userlocations, ignore_missing_singleparams=["Mw"], verbose=verbose)
     c1 = params["c1"]
     packagedparams = CPAAlphaParam(c1)

--- a/src/models/cubic/alphas/ClausiusAlpha.jl
+++ b/src/models/cubic/alphas/ClausiusAlpha.jl
@@ -10,7 +10,7 @@ export ClausiusAlpha
     ClausiusAlpha <: ClausiusAlphaModel
     
     ClausiusAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -32,7 +32,7 @@ Trᵢ = T/Tcᵢ
 """
 ClausiusAlpha
 
-function ClausiusAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function ClausiusAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     packagedparams = ClausiusAlphaParam()
     model = ClausiusAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/KUAlpha.jl
+++ b/src/models/cubic/alphas/KUAlpha.jl
@@ -11,7 +11,7 @@ export KUAlpha
     KUAlpha <: AlphaModel
     
     KUAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -37,7 +37,7 @@ For `Tr > 1` is a 6th order taylor expansion around `T = Tc`.
 """
 KUAlpha
 
-function KUAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function KUAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = KUAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/MT.jl
+++ b/src/models/cubic/alphas/MT.jl
@@ -9,7 +9,7 @@ export MTAlpha
     MTAlpha <: MTAlphaModel
     
     MTAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -33,7 +33,7 @@ mᵢ = 0.384401 + 1.52276ωᵢ - 0.213808ωᵢ^2 + 0.034616ωᵢ^3 - 0.001976ω�
 """
 MTAlpha
 
-function MTAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function MTAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = MTAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/NoAlpha.jl
+++ b/src/models/cubic/alphas/NoAlpha.jl
@@ -18,7 +18,7 @@ Cubic alpha `(α(T))` model. Default for [`vdW`](@ref) EoS
 """
 NoAlpha
 
-function NoAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function NoAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     model = NoAlpha(NoAlphaParam())
     return model
 end

--- a/src/models/cubic/alphas/PR78Alpha.jl
+++ b/src/models/cubic/alphas/PR78Alpha.jl
@@ -11,7 +11,7 @@ export PR78Alpha
     PR78Alpha <: PR78AlphaModel
     
     PR78Alpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -31,7 +31,7 @@ else
 """
 PR78Alpha
 
-function PR78Alpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function PR78Alpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = PR78AlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/PRAlpha.jl
+++ b/src/models/cubic/alphas/PRAlpha.jl
@@ -9,7 +9,7 @@ export PRAlpha
     PRAlpha <: SoaveAlphaModel
     
     PRAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -26,7 +26,7 @@ mᵢ = 0.37464 + 1.54226ωᵢ - 0.26992ωᵢ^2
 """
 PRAlpha
 
-function PRAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function PRAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = PRAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/PTVAlpha.jl
+++ b/src/models/cubic/alphas/PTVAlpha.jl
@@ -11,7 +11,7 @@ export PTVAlpha
     PTVAlpha <: PTVAlphaModel
     
     PTVAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -30,7 +30,7 @@ mᵢ = 0.46283 + 3.58230Zcᵢ*ωᵢ - 8.19417(Zcᵢ*ωᵢ)^2
 """
 PTVAlpha
 
-function PTVAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function PTVAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = PTVAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/PatelTejaAlpha.jl
+++ b/src/models/cubic/alphas/PatelTejaAlpha.jl
@@ -9,7 +9,7 @@ export PatelTejaAlpha
     PatelTejaAlpha <: SoaveAlphaModel
     
     PatelTejaAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -28,7 +28,7 @@ mᵢ = 0.452413 + 1.30982ωᵢ - 0.295937ωᵢ^2
 """
 PatelTejaAlpha
 
-function PatelTejaAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function PatelTejaAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = PatelTejaAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/RKAlpha.jl
+++ b/src/models/cubic/alphas/RKAlpha.jl
@@ -10,7 +10,7 @@ export RKAlpha
     RKAlpha <: RKAlphaModel
     
     RKAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -32,7 +32,7 @@ Trᵢ = T/Tcᵢ
 """
 RKAlpha
 
-function RKAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function RKAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     packagedparams = RKAlphaParam()
     model = RKAlpha(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/alphas/RKPRAlpha.jl
+++ b/src/models/cubic/alphas/RKPRAlpha.jl
@@ -11,7 +11,7 @@ export RKPRAlpha
     RKPRAlpha <: RKPRAlphaModel
     
     RKPRAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -30,7 +30,7 @@ Trᵢ = T/Tcᵢ
 """
 RKPRAlpha
 
-function RKPRAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function RKPRAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = RKPRAlphaParam(acentricfactor)

--- a/src/models/cubic/alphas/Twu.jl
+++ b/src/models/cubic/alphas/Twu.jl
@@ -12,7 +12,7 @@ end
     TwuAlpha <: TwuAlphaModel
     
     TwuAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 ## Input Parameters
 - `M`: Single Parameter
@@ -34,7 +34,7 @@ Trᵢ = T/Tcᵢ
 TwuAlpha
 
 export TwuAlpha
-function TwuAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function TwuAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["alpha/Twu/Twu_like.csv"]; userlocations=userlocations, verbose=verbose)
     M = params["M"]
     N = params["N"]

--- a/src/models/cubic/alphas/sCPAAlpha.jl
+++ b/src/models/cubic/alphas/sCPAAlpha.jl
@@ -25,10 +25,10 @@ Cubic alpha `(α(T))` model. Default for `sCPA` EoS.
 sCPAAlpha
 
 export sCPAAlpha
-function sCPAAlpha(components::Vector{String}; userlocationskwargs...)
+function sCPAAlpha(components::Vector{String};userlocations = String[],verbose = false)
     params = getparams(components, ["SAFT/CPA/sCPA/sCPA_like.csv"]; userlocations=userlocations, ignore_missing_singleparams=["Mw"], verbose=verbose)
     c1 = params["c1"]
     packagedparams = CPAAlphaParam(c1)
-    model = sCPAAlpha(packagedparams, verbose=verbose)
+    model = sCPAAlpha(packagedparams,verbose = verbose)
     return model
 end

--- a/src/models/cubic/alphas/sCPAAlpha.jl
+++ b/src/models/cubic/alphas/sCPAAlpha.jl
@@ -7,7 +7,7 @@ abstract type sCPAAlphaModel <: CPAAlphaModel end
     sCPAAlpha <: sCPAAlphaModel
     
     CPAAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -25,7 +25,7 @@ Cubic alpha `(α(T))` model. Default for `sCPA` EoS.
 sCPAAlpha
 
 export sCPAAlpha
-function sCPAAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false, kwargs...)
+function sCPAAlpha(components::Vector{String}; userlocationskwargs...)
     params = getparams(components, ["SAFT/CPA/sCPA/sCPA_like.csv"]; userlocations=userlocations, ignore_missing_singleparams=["Mw"], verbose=verbose)
     c1 = params["c1"]
     packagedparams = CPAAlphaParam(c1)

--- a/src/models/cubic/alphas/soave.jl
+++ b/src/models/cubic/alphas/soave.jl
@@ -11,7 +11,7 @@ export SoaveAlpha
     SoaveAlpha <: SoaveAlphaModel
     
     SoaveAlpha(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -32,7 +32,7 @@ to use different polynomial coefficients for `mᵢ`, overload `Clapeyron.α_m(::
 """
 SoaveAlpha
 
-function SoaveAlpha(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function SoaveAlpha(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = SoaveAlphaParam(acentricfactor)

--- a/src/models/cubic/mixing/HV.jl
+++ b/src/models/cubic/mixing/HV.jl
@@ -12,8 +12,8 @@ end
 
     HVRule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -47,7 +47,7 @@ for Peng-Robinson:
 HVRule
 
 export HVRule
-function HVRule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function HVRule(components::Vector{String}; activity = Wilson, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1016/0378-3812(79)80001-1"]
     model = HVRule(components, _activity,references)

--- a/src/models/cubic/mixing/Kay.jl
+++ b/src/models/cubic/mixing/Kay.jl
@@ -9,7 +9,7 @@ end
     KayRule <: KayRuleModel
     
     KayRule(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -32,7 +32,7 @@ KayRule
 
 export KayRule
 
-function KayRule(components::Vector{String}; activity=nothing, userlocations::Vector{String}=String[], activity_userlocations::Vector{String}=String[], verbose::Bool=false, kwargs...)
+function KayRule(components::Vector{String}; activity=nothing, userlocations=String[], activity_userlocations=String[], verbose::Bool=false, kwargs...)
     #params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     #acentricfactor = params["acentricfactor"]
     packagedparams = KayRuleParam()

--- a/src/models/cubic/mixing/LCVM.jl
+++ b/src/models/cubic/mixing/LCVM.jl
@@ -13,8 +13,8 @@ end
 
     LCVMRule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -46,7 +46,7 @@ ā = b̄RT(-1.827[gᴱ/RT - 0.3∑log(bᵢᵢ/b̄)] + Σᾱᵢxᵢ)
 LCVMRule
 
 export LCVMRule
-function LCVMRule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function LCVMRule(components::Vector{String}; activity = Wilson, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1016/0378-3812(94)80043-X"]
     model = LCVMRule(components, _activity,references)

--- a/src/models/cubic/mixing/MHV1.jl
+++ b/src/models/cubic/mixing/MHV1.jl
@@ -13,8 +13,8 @@ end
 
     MHV1Rule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -51,7 +51,7 @@ to use different values for `q`, overload `Clapeyron.MHV1q(::CubicModel,::MHV1Mo
 MHV1Rule
 
 export MHV1Rule
-function MHV1Rule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function MHV1Rule(components::Vector{String}; activity = Wilson, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1016/0378-3812(90)85053-D"]
     model = MHV1Rule(components, _activity,references)

--- a/src/models/cubic/mixing/MHV2.jl
+++ b/src/models/cubic/mixing/MHV2.jl
@@ -13,8 +13,8 @@ end
 
     MHV2Rule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -55,7 +55,7 @@ MHV2Rule
 
 
 export MHV2Rule
-function MHV2Rule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function MHV2Rule(components::Vector{String}; activity = Wilson, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
 
     references = ["10.1016/0378-3812(90)85053-D"]

--- a/src/models/cubic/mixing/PSRK.jl
+++ b/src/models/cubic/mixing/PSRK.jl
@@ -11,8 +11,8 @@ end
 
     PSRKRule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -31,7 +31,7 @@ derived from the First Order modified Huron-Vidal Mixing Rule.
 PSRKRule
 
 export PSRKRule
-function PSRKRule(components::Vector{String}; activity = PSRKUNIFAC, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function PSRKRule(components::Vector{String}; activity = PSRKUNIFAC, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = String["10.1016/0378-3812(91)85038-V"]
     model = PSRKRule(components, _activity,references)

--- a/src/models/cubic/mixing/QCPR.jl
+++ b/src/models/cubic/mixing/QCPR.jl
@@ -19,8 +19,8 @@ end
     
     QCPRRule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 ## Input Parameters
 None
@@ -43,7 +43,7 @@ c̄ = ∑cᵢxᵢ
 QCPRRule
 
 
-function QCPRRule(components::Vector{String}; activity = nothing, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function QCPRRule(components::Vector{String}; activity = nothing, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["cubic/QCPR/QCPR_like.csv","cubic/QCPR/QCPR_unlike.csv"]; userlocations=userlocations, verbose=verbose)
     references = String["10.1016/j.fluid.2020.112790"]
     pkgparams = QCPRRuleParam(params["A"],params["B"],params["l"])

--- a/src/models/cubic/mixing/UMR.jl
+++ b/src/models/cubic/mixing/UMR.jl
@@ -13,8 +13,8 @@ end
 
     UMRRule(components::Vector{String};
     activity = UNIFAC,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 ## Input Parameters
 None
@@ -34,7 +34,7 @@ ā = b̄RT(∑[xᵢaᵢᵢαᵢ/(RTbᵢᵢ)] - [gᴱ/RT]/0.53)
 """
 UMRRule
 export UMRRule
-function UMRRule(components::Vector{String}; activity = UNIFAC, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function UMRRule(components::Vector{String}; activity = UNIFAC, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1021/ie049580p"]
     model = UMRRule(components, _activity,references)

--- a/src/models/cubic/mixing/VTPR.jl
+++ b/src/models/cubic/mixing/VTPR.jl
@@ -13,8 +13,8 @@ end
 
     VTPRRule(components::Vector{String};
     activity = UNIFAC,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -46,7 +46,7 @@ ā = b̄RT(∑[xᵢaᵢᵢαᵢ/(RTbᵢᵢ)] - gᴱᵣₑₛ/(0.53087RT))
 VTPRRule
 
 export VTPRRule
-function VTPRRule(components::Vector{String}; activity = UNIFAC, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function VTPRRule(components::Vector{String}; activity = UNIFAC, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1016/S0378-3812(01)00626-4"]
     model = VTPRRule(components, _activity,references)

--- a/src/models/cubic/mixing/WS.jl
+++ b/src/models/cubic/mixing/WS.jl
@@ -13,8 +13,8 @@ end
 
     WSRule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -51,7 +51,7 @@ for Peng-Robinson:
 WSRule
 
 export WSRule
-function WSRule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function WSRule(components::Vector{String}; activity = Wilson, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1002/aic.690380505"]
     model = WSRule(components, _activity,references)

--- a/src/models/cubic/mixing/modWS.jl
+++ b/src/models/cubic/mixing/modWS.jl
@@ -13,8 +13,8 @@ end
 
     WSRule(components::Vector{String};
     activity = Wilson,
-    userlocations::Vector{String}=String[],
-    activity_userlocations::Vector{String}=String[],
+    userlocations=String[],
+    activity_userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -51,7 +51,7 @@ for Peng-Robinson:
 modWSRule
 
 export modWSRule
-function modWSRule(components::Vector{String}; activity = Wilson, userlocations::Vector{String}=String[],activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function modWSRule(components::Vector{String}; activity = Wilson, userlocations=String[],activity_userlocations=String[], verbose::Bool=false)
     _activity = init_model(activity,components,activity_userlocations,verbose)
     references = ["10.1002/aic.690380505","10.1002/aic.690410325"]
     model = modWSRule(components, _activity,references)

--- a/src/models/cubic/mixing/vdW1f.jl
+++ b/src/models/cubic/mixing/vdW1f.jl
@@ -10,7 +10,7 @@ export vdW1fRule
     vdW1fRule <: vdW1fRuleModel
     
     vdW1fRule(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 ## Input Parameters
 None
@@ -26,7 +26,7 @@ c̄ = ∑cᵢxᵢ
 """
 vdW1fRule
 
-function vdW1fRule(components::Vector{String}; activity=nothing, userlocations::Vector{String}=String[], activity_userlocations::Vector{String}=String[], verbose::Bool=false)
+function vdW1fRule(components::Vector{String}; activity=nothing, userlocations=String[], activity_userlocations=String[], verbose::Bool=false)
     packagedparams = vdW1fRuleParam()
     model = vdW1fRule(packagedparams, verbose=verbose)
     return model

--- a/src/models/cubic/translation/Clausius.jl
+++ b/src/models/cubic/translation/Clausius.jl
@@ -11,7 +11,7 @@ end
     ClausiusTranslation <: ClausiusTranslationModel
 
     ClausiusTranslation(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations
     verbose::Bool=false)
 
 ## Input Parameters
@@ -35,7 +35,7 @@ where `kᵢ` is the Cubic EoS calculated critical compresibility factor
 ClausiusTranslation
 
 export ClausiusTranslation
-function ClausiusTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function ClausiusTranslation(components::Vector{String}; userlocations
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose)
     Vc = params["Vc"]
     packagedparams = ClausiusTranslationParam(Vc)

--- a/src/models/cubic/translation/ConstantTranslation.jl
+++ b/src/models/cubic/translation/ConstantTranslation.jl
@@ -9,7 +9,7 @@ end
 """
     ConstantTranslation <: ConstantTranslationModel
     ConstantTranslation(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 ## Input Parameters
 
@@ -27,7 +27,7 @@ ConstantTranslation
 
 export ConstantTranslation
 
-function ConstantTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function ConstantTranslation(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, String[]; userlocations=userlocations, verbose=verbose)
     c = params["v_shift"]
     packagedparams = ConstantTranslationParam(c)

--- a/src/models/cubic/translation/MT.jl
+++ b/src/models/cubic/translation/MT.jl
@@ -12,7 +12,7 @@ export MTTranslation
 MTTranslation <: MTTranslationModel
 
     MTTranslation(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -39,7 +39,7 @@ Zcᵢ = 0.289 - 0.0701ωᵢ - 0.0207ωᵢ^2
 """
 MTTranslation
 
-function MTTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function MTTranslation(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_ACENTRICFACTOR)
     acentricfactor = params["acentricfactor"]
     packagedparams = MTTranslationParam(acentricfactor)

--- a/src/models/cubic/translation/NoTranslation.jl
+++ b/src/models/cubic/translation/NoTranslation.jl
@@ -26,7 +26,7 @@ cᵢ = 0 ∀ i
 """
 NoTranslation
 
-function NoTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false, kwargs...)
+function NoTranslation(components::Vector{String}; userlocations=String[], verbose::Bool=false, kwargs...)
     model = NoTranslation(NoTranslationParam())
     return model
 end

--- a/src/models/cubic/translation/Peneloux.jl
+++ b/src/models/cubic/translation/Peneloux.jl
@@ -12,7 +12,7 @@ end
     PenelouxTranslation <: PenelouxTranslationModel
 
     PenelouxTranslation(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -42,7 +42,7 @@ Zcᵢ = Pcᵢ*Vcᵢ/(RTcᵢ)
 PenelouxTranslation
 
 export PenelouxTranslation
-function PenelouxTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function PenelouxTranslation(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_VC)
     Vc = params["Vc"]
     c = SingleParam("Volume shift",components,zeros(length(components)))

--- a/src/models/cubic/translation/Rackett.jl
+++ b/src/models/cubic/translation/Rackett.jl
@@ -11,7 +11,7 @@ end
     RackettTranslation <: RackettTranslationModel
 
     RackettTranslation(components::Vector{String};
-    userlocations::Vector{String}=String[],
+    userlocations=String[],
     verbose::Bool=false)
 
 ## Input Parameters
@@ -39,7 +39,7 @@ Zcᵢ = Pcᵢ*Vcᵢ/(RTcᵢ)
 RackettTranslation
 
 export RackettTranslation
-function RackettTranslation(components::Vector{String}; userlocations::Vector{String}=String[], verbose::Bool=false)
+function RackettTranslation(components::Vector{String}; userlocations=String[], verbose::Bool=false)
     params = getparams(components, ["properties/critical.csv"]; userlocations=userlocations, verbose=verbose,ignore_headers = ONLY_VC)
     Vc = params["Vc"]
     c = SingleParam("Volume shift",components,zeros(length(components)))

--- a/src/utils/macros.jl
+++ b/src/utils/macros.jl
@@ -381,7 +381,7 @@ the necessary traits to make the model compatible with Clapeyron routines.
 
 """
 macro registermodel(model)
-    _model = getfield(@__MODULE__(),model)
+    _model = getfield(__module__,model)
     ∅ = :()
 
     _has_components = hasfield(_model,:components)

--- a/src/utils/macros.jl
+++ b/src/utils/macros.jl
@@ -134,7 +134,7 @@ macro newmodelgc(name, parent, paramstype)
     function $name(params::$paramstype,
         groups::GroupParam,
         idealmodel::IDEALTYPE = BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::Clapeyron.AssocOptions = Clapeyron.AssocOptions(),
         verbose::Bool = false)
@@ -146,7 +146,7 @@ macro newmodelgc(name, parent, paramstype)
         groups::GroupParam,
         sites::SiteParam,
         idealmodel::IDEALTYPE = BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::Clapeyron.AssocOptions = Clapeyron.AssocOptions(),
         verbose::Bool = false)
@@ -191,7 +191,7 @@ macro newmodel(name, parent, paramstype)
     function $name(params::$paramstype,
         sites::SiteParam,
         idealmodel::IDEALTYPE = Clapeyron.BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::Clapeyron.AssocOptions = Clapeyron.AssocOptions(),
         verbose::Bool = false)
@@ -201,7 +201,7 @@ macro newmodel(name, parent, paramstype)
 
     function $name(params::$paramstype,
         idealmodel::IDEALTYPE = Clapeyron.BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::AssocOptions = Clapeyron.AssocOptions(),
         verbose::Bool = false)
@@ -249,7 +249,7 @@ function build_model(::Type{model},params::EoSParam,
         groups::GroupParam,
         sites::SiteParam,
         idealmodel::IDEALTYPE = BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
@@ -265,7 +265,7 @@ end
 function build_model(::Type{model},params::EoSParam,
         groups::GroupParam,
         idealmodel::IDEALTYPE = BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
@@ -278,7 +278,7 @@ end
 function build_model(::Type{model},params::EoSParam,
         sites::SiteParam,
         idealmodel::IDEALTYPE = BasicIdeal;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel
@@ -294,7 +294,7 @@ end
 #normal macro model
 function build_model(::Type{model},params::EoSParam,
         idealmodel::IDEALTYPE;
-        ideal_userlocations::Vector{String}=String[],
+        ideal_userlocations=String[],
         references::Vector{String}=String[],
         assoc_options::AssocOptions = AssocOptions(),
         verbose::Bool = false) where model <:EoSModel

--- a/test/test_database.jl
+++ b/test/test_database.jl
@@ -272,10 +272,22 @@ using Clapeyron, Test, LinearAlgebra
 
     #named tuple constructor:
 
-    model_nt = PCSAFT(["a1"],userlocations = (;Mw = [1.],epsilon = [2.],sigma = [3.],segment = [4.],epsilon_assoc = nothing, bondvol = nothing))
+    model_nt = PCSAFT(["a1"],userlocations = (;
+        Mw = [1.],
+        epsilon = [2.],
+        sigma = [3.],
+        segment = [4.],
+        n_H = [1],
+        n_e = [1],
+        epsilon_assoc = Dict((("a1","e"),("a1","H")) => 1000.), 
+        bondvol = Dict((("a1","e"),("a1","H")) => 0.001)))
+    
+    
     @test model_nt.params.Mw[1] == 1.
     @test model_nt.params.epsilon[1] == 2.
-    @test model_nt.params.sigma[1] == 3.
+    @test model_nt.params.sigma[1] == 3e-10 #pcsaft multiplies sigma by 1e-10
     @test model_nt.params.segment[1] == 4.
+    @test model_nt.params.epsilon_assoc.values.values[1] == 1000.
+    @test model_nt.params.bondvol.values.values[1] == 0.001
 end
 

--- a/test/test_database.jl
+++ b/test/test_database.jl
@@ -269,5 +269,13 @@ using Clapeyron, Test, LinearAlgebra
     #@REPLACE keyword
     param_user3 = Clapeyron.getparams(["sp1","sp2"],userlocations = [file, "@REPLACE/" * csv_string],ignore_missing_singleparams = ["userparam"])
     @test param_user3["userparam"].ismissingvalues[2] == true
+
+    #named tuple constructor:
+
+    model_nt = PCSAFT(["a1"],userlocations = (;Mw = [1.],epsilon = [2.],sigma = [3.],segment = [4.],epsilon_assoc = nothing, bondvol = nothing))
+    @test model_nt.params.Mw[1] == 1.
+    @test model_nt.params.epsilon[1] == 2.
+    @test model_nt.params.sigma[1] == 3.
+    @test model_nt.params.segment[1] == 4.
 end
 


### PR DESCRIPTION
to make building models in the REPL even easier:
```
julia> model = PCSAFT(["a1"],userlocations = (;
        Mw = [1.],
        epsilon = [2.],
        sigma = [3.],
        segment = [4.],
        k = [0.0;;], #matrix
        n_H = [1],
        n_e = [1],
        epsilon_assoc = Dict((("a1","e"),("a1","H")) => 1000.),
        bondvol = Dict((("a1","e"),("a1","H")) => 0.001)))
PCSAFT{BasicIdeal} with 1 component:
 "a1"
Contains parameters: Mw, segment, sigma, epsilon, epsilon_assoc, bondvol
```
how it works?
when passing a named tuple, we perform a less strict parsing of the params, and transform to Single, Pair, Group or StructGroup depending on the shape of the data, or if the function is called from a `GroupParameter`. instead of doing locations -> csv -> tape -> param, we do namedtuple -> tape -> param and special-case when the component info is `nothing`

~~the big TODO here is the association parameters. at the moment, this works for any models that only uses single, pair or group parameters. but on association, this allows for only setting null association and it is hardcoded to `bondvol` and `epsilon_assoc`.~~
Association is done by passing `Dict{NTuple{2,Ntuple{2,String}},T}`. the special casing for `epsilon_assoc` and `bondvol` is still there to allow to set no-assoc models easily.

things to do:
- ~~tests~~
- docs
