### PR TITLE
revamp kwarg and dispatch handling for methods (NFC)

### DIFF
--- a/src/base/EoSModel.jl
+++ b/src/base/EoSModel.jl
@@ -19,6 +19,7 @@ You can mix and match ideal models if you provide:
 function eos(model::EoSModel, V, T, z=SA[1.0])
     return N_A*k_B*sum(z)*T * (a_ideal(idealmodel(model),V,T,z)+a_res(model,V,T,z))
 end
+
 """
     idealmodel(model::EoSModel)
     
@@ -80,12 +81,11 @@ Base.broadcastable(model::EoSModel) = Ref(model)
 Base.transpose(model::EoSModel) = model
 """
     @comps
-This macro is an alias to
-    1:length(model)
+
+This macro is an alias to `1:length(model)`
 The caveat is that `model` has to exist in the local namespace.
 `model` is expected to any struct that has length defined in terms of the amount of components.
 """
-
 macro comps()
     return quote
         1:length(model)

--- a/src/methods/methods.jl
+++ b/src/methods/methods.jl
@@ -218,6 +218,14 @@ function gradient_type(V,T,z::FractionVector)
     return Vector{μ}
 end
 
+"""
+    init_preferred_method(method,model,kwargs)
+
+Returns the preferred method for a combination of model and function, with the specified kwargs.
+
+"""
+function __preferred_method(method,model) end
+
 include("initial_guess.jl")
 include("differentials.jl")
 include("VT.jl")

--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -314,7 +314,7 @@ function bubble_temperature(model::EoSModel,p,x;kwargs...)
     else
         method = init_preferred_method(bubble_temperature,model,kwargs)
     end
-    return bubble_temperature(model,p,x,ChemPotBubbleTemperature(;T0,vol0,y0))
+    return bubble_temperature(model,p,x,method)
 end
 
 function bubble_temperature(model::EoSModel, p , x, T0::Number)

--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -317,6 +317,12 @@ function bubble_temperature(model::EoSModel,p,x;kwargs...)
     return bubble_temperature(model,p,x,ChemPotBubbleTemperature(;T0,vol0,y0))
 end
 
+function bubble_temperature(model::EoSModel, p , x, T0::Number)
+    kwargs = (;T0)
+    method = init_preferred_method(bubble_temperature,model,kwargs)
+    return bubble_temperature(model,p,x,method)
+end
+
 function bubble_temperature(model::EoSModel, p , x, method::BubblePointMethod)
     x = x/sum(x)
     p = float(p)
@@ -337,15 +343,6 @@ function bubble_temperature(model::EoSModel, p , x, method::BubblePointMethod)
         return (nan,nan,nan,y)
     end
 end
-
-function bubble_temperature(model::EoSModel, p , x, T0::Number)
-    kwargs = (;T0)
-    method = init_preferred_method(bubble_temperature,model,kwargs)
-    return bubble_temperature(model,p,x,method)
-end
-
-
-
 
 include("bubble_point/bubble_activity.jl")
 include("bubble_point/bubble_chempot.jl")

--- a/src/methods/property_solvers/multicomponent/multicomponent.jl
+++ b/src/methods/property_solvers/multicomponent/multicomponent.jl
@@ -159,9 +159,6 @@ include("UCST_mix.jl")
 include("tp_flash.jl")
 
 export bubble_pressure_fug, bubble_temperature_fug, dew_temperature_fug, dew_pressure_fug
-
 export bubble_pressure,    dew_pressure,    LLE_pressure,    azeotrope_pressure, VLLE_pressure
 export bubble_temperature, dew_temperature, LLE_temperature, azeotrope_temperature, VLLE_temperature
-export dew_pressure_fug_condensable, dew_temperature_fug_condensable
-export bubble_pressure_fug_volatile, bubble_temperature_fug_volatile
 export crit_mix, UCEP_mix, UCST_mix

--- a/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
@@ -166,9 +166,5 @@ function try_sat_temp(model,p,T0,Vl,Vv,scales,method::AntoineSaturation)
     return (T,Vl,Vv),converged
 end
 
-#Default!
-function saturation_temperature(model,p)
-    return saturation_temperature(model,p,AntoineSaturation())
-end
 
 export AntoineSaturation

--- a/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/AntoineSat.jl
@@ -47,13 +47,6 @@ function AntoineSaturation(;T0 = nothing,
     end
 end
 
-#if a number is provided as initial point, it will instead proceed to solve directly
-function saturation_temperature(model::EoSModel, p, T0::Number)
-    sat = x0_sat_pure(model,T0)
-    T0,vl,vv = promote(T0,sat[1],sat[2])
-    return saturation_temperature_impl(model,p,AntoineSaturation(;T0,vl,vv))
-end
-
 function Obj_Sat_Temp(model::EoSModel, F, T, V_l, V_v,p,scales,method::AntoineSaturation)
     fun(_V) = eos(model, _V, T,SA[1.])
     A_l,Av_l = Solvers.f∂f(fun,V_l)

--- a/src/methods/property_solvers/singlecomponent/saturation/ChemPotV.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/ChemPotV.jl
@@ -26,7 +26,6 @@ struct ChemPotVSaturation{T,C} <: SaturationMethod
     max_iters::Int
 end
 
-
 function ChemPotVSaturation(;vl = nothing,
                             vv = nothing,
                             crit = nothing,
@@ -50,8 +49,6 @@ function ChemPotVSaturation(;vl = nothing,
         return ChemPotVSaturation(vl,vv,crit,crit_retry,f_limit,atol,rtol,max_iters)
     end
 end
-
-
 
 function saturation_pressure_impl(model::EoSModel, T, method::ChemPotVSaturation{Nothing})
     vl,vv = x0_sat_pure(model,T)

--- a/src/methods/property_solvers/singlecomponent/saturation/ChemPotV.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/ChemPotV.jl
@@ -26,8 +26,6 @@ struct ChemPotVSaturation{T,C} <: SaturationMethod
     max_iters::Int
 end
 
-ChemPotVSaturation(x::Tuple) = ChemPotVSaturation(vl = first(x),vv = last(x))
-ChemPotVSaturation(x::Vector) = ChemPotVSaturation(vl = first(x),vv = last(x))
 
 function ChemPotVSaturation(;vl = nothing,
                             vv = nothing,
@@ -53,16 +51,7 @@ function ChemPotVSaturation(;vl = nothing,
     end
 end
 
-function saturation_pressure(model::EoSModel,T,V0::Union{Tuple,Vector})
-    single_component_check(saturation_pressure,model)
-    method = ChemPotVSaturation(V0)
-    T = T*T/T
-    return saturation_pressure_impl(model,T,method)
-end
 
-function saturation_pressure(model::EoSModel,T)
-   saturation_pressure(model,T,ChemPotVSaturation())
-end
 
 function saturation_pressure_impl(model::EoSModel, T, method::ChemPotVSaturation{Nothing})
     vl,vv = x0_sat_pure(model,T)

--- a/src/methods/property_solvers/singlecomponent/saturation/ChemPotV.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/ChemPotV.jl
@@ -50,6 +50,9 @@ function ChemPotVSaturation(;vl = nothing,
     end
 end
 
+ChemPotVSaturation(x::Tuple) = ChemPotVSaturation(vl = first(x),vv = last(x))
+ChemPotVSaturation(x::Vector) = ChemPotVSaturation(vl = first(x),vv = last(x))
+
 function saturation_pressure_impl(model::EoSModel, T, method::ChemPotVSaturation{Nothing})
     vl,vv = x0_sat_pure(model,T)
     crit = method.crit

--- a/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
@@ -44,7 +44,16 @@ function saturation_pressure(model::EoSModel,T,method::SaturationMethod)
 end
 
 function saturation_pressure(model::EoSModel,T;kwargs...)
-    method = init_preferred_method(saturation_pressure,model,kwargs)
+    if keys(kwargs) == (:v0,)
+        nt_kwargs = NamedTuple(kwargs)
+        v0 = nt_kwargs.v0
+        vl = first(v0)
+        vv = last(v0)
+        _kwargs = (;vl,vv)
+        method = init_preferred_method(saturation_pressure,model,_kwargs)
+    else
+        method = init_preferred_method(saturation_pressure,model,kwargs)
+    end
     return saturation_pressure(model,T,method)
 end
 
@@ -167,15 +176,7 @@ end
 #default initializers for saturation pressure and saturation temperature
 
 function init_preferred_method(method::typeof(saturation_pressure),model::EoSModel,kwargs)
-    if keys(kwargs) == (:v0,)
-        nt_kwargs = NamedTuple(kwargs)
-        v0 = nt_kwargs.v0
-        vl = first(v0)
-        vv = last(v0)
-        return ChemPotVSaturation(;vl,vv)
-    else
-        return ChemPotVSaturation(;kwargs...)
-    end
+    ChemPotVSaturation(;kwargs...)
 end
 
 function init_preferred_method(method::typeof(saturation_temperature),model::EoSModel,kwargs)

--- a/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
@@ -7,7 +7,6 @@ Should at least support passing the `crit` keyword, containing the critical poin
 """
 abstract type SaturationMethod <: ThermodynamicMethod end
 
-
 """
     saturation_pressure(model::EoSModel, T)
     saturation_pressure(model::EoSModel,T,method::SaturationMethod)
@@ -44,6 +43,21 @@ function saturation_pressure(model::EoSModel,T,method::SaturationMethod)
     return saturation_pressure_impl(model,T,method)
 end
 
+function saturation_pressure(model::EoSModel,T;kwargs...)
+    method = init_preferred_method(saturation_pressure,model,kwargs)
+    return saturation_pressure(model,T,method)
+end
+
+function saturation_pressure(model::EoSModel,T,V0::Union{Tuple,Vector})
+    single_component_check(saturation_pressure,model)
+    vl = first(V0)
+    vv = last(V0)
+    kwargs = (;vl,vv)
+    method = init_preferred_method(saturation_pressure,model,kwargs)
+    return saturation_pressure(model,T,method)
+end
+
+
 """
     check_valid_sat_pure(model,P_sat,Vl,Vv,T,ε0 = 5e7)
 
@@ -61,9 +75,9 @@ function check_valid_sat_pure(model,P_sat,V_l,V_v,T,ε0 = 5e7)
 end
 
 """
-    saturation_pressure(model::EoSModel, p)
-    saturation_pressure(model::EoSModel, p, method::SaturationMethod)
-    saturation_pressure(model, p, T0::Number)
+    saturation_temperature(model::EoSModel, p, kwargs...)
+    saturation_temperature(model::EoSModel, p, method::SaturationMethod)
+    saturation_temperature(model, p, T0::Number)
 
 Performs a single component saturation temperature equilibrium calculation, at the specified pressure `T`, of one mol of pure sustance specified by `model`
 
@@ -92,6 +106,13 @@ function saturation_temperature(model,p,method::SaturationMethod)
     single_component_check(crit_pure,model)
     p = p*p/p
     return saturation_temperature_impl(model,p,method)
+end
+
+#if a number is provided as initial point, it will instead proceed to solve directly
+function saturation_temperature(model::EoSModel, p, T0::Number)
+    kwargs = (;T0)
+    method = init_preferred_method(saturation_temperature,model,kwargs)
+    saturation_temperature(model,p,method)
 end
 
 include("ChemPotV.jl")
@@ -143,6 +164,20 @@ function saturation_liquid_density(model::EoSModel,T,satmethod = ChemPotVSaturat
     return saturation_pressure(model,T,satmethod)[2]
 end
 
-#tsat, psat interface
-include("tsat_psat.jl")
+#default initializers for saturation pressure and saturation temperature
 
+function init_preferred_method(method::typeof(saturation_pressure),model::EoSModel,kwargs)
+    if keys(kwargs) == (:v0,)
+        nt_kwargs = NamedTuple(kwargs)
+        v0 = nt_kwargs.v0
+        vl = first(v0)
+        vv = last(v0)
+        return ChemPotVSaturation(;vl,vv)
+    else
+        return ChemPotVSaturation(;kwargs...)
+    end
+end
+
+function init_preferred_method(method::typeof(saturation_temperature),model::EoSModel,kwargs)
+    return AntoineSaturation(;kwargs...)
+end

--- a/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
@@ -111,6 +111,11 @@ julia> saturation_pressure(pr,Ts)
 (100000.00004314569, 2.269760164804427e-5, 0.03084938795785433)
 ```
 """
+function saturation_temperature(model,p;kwargs...)
+    method = init_preferred_method(saturation_temperature,model,kwargs)
+    return saturation_temperature(model,p,method)
+end
+
 function saturation_temperature(model,p,method::SaturationMethod)
     single_component_check(crit_pure,model)
     p = p*p/p

--- a/src/models/Activity/methods/Michelsentp_flash.jl
+++ b/src/models/Activity/methods/Michelsentp_flash.jl
@@ -1,4 +1,7 @@
 #special support for activity models with the michelsen tp flash method.
+function init_preferred_method(method::typeof(tp_flash),model::ActivityModel,kwargs)
+    return RRTPFlash(;kwargs...)
+end
 
 function PTFlashWrapper(model::ActivityModel,T::Number) 
     pures = model.puremodel.pure

--- a/src/models/Activity/methods/bubble_point.jl
+++ b/src/models/Activity/methods/bubble_point.jl
@@ -1,6 +1,6 @@
 function init_preferred_method(method::typeof(bubble_pressure),model::ActivityModel,kwargs)
-    gas_fug = get(kwargs,gas_fug,false)
-    poynting = get(poynting,gas_fug,false)
+    gas_fug = get(kwargs,:gas_fug,false)
+    poynting = get(kwargs,:poynting,false)
     return ActivityBubblePressure(;gas_fug,poynting,kwargs...)
 end
 
@@ -82,8 +82,8 @@ function bubble_pressure_impl(model::ActivityModel,T,x,method::ActivityBubblePre
 end
 
 function init_preferred_method(method::typeof(bubble_temperature),model::ActivityModel,kwargs)
-    gas_fug = get(kwargs,gas_fug,false)
-    poynting = get(poynting,gas_fug,false)
+    gas_fug = get(kwargs,:gas_fug,false)
+    poynting = get(kwargs,:poynting,false)
     return ActivityBubbleTemperature(;gas_fug,poynting,kwargs...)
 end
 

--- a/src/models/Activity/methods/bubble_point.jl
+++ b/src/models/Activity/methods/bubble_point.jl
@@ -1,5 +1,7 @@
-function bubble_pressure(model::ActivityModel,T,x)
-    bubble_pressure(model,T,x,ActivityBubblePressure(gas_fug = false, poynting = false))
+function init_preferred_method(method::typeof(bubble_pressure),model::ActivityModel,kwargs)
+    gas_fug = get(kwargs,gas_fug,false)
+    poynting = get(poynting,gas_fug,false)
+    return ActivityBubblePressure(;gas_fug,poynting,kwargs...)
 end
 
 function bubble_pressure(model::ActivityModel, T, x, method::BubblePointMethod)
@@ -8,9 +10,9 @@ function bubble_pressure(model::ActivityModel, T, x, method::BubblePointMethod)
     end
     _T = typeof(T)
     _x = typeof(x)
+    #this is done to reuse the index_reduction strategy done in the main function.
     Base.invoke(bubble_pressure,Tuple{EoSModel,_T,_x,BubblePointMethod},model,T,x,method)
 end
-
 
 function bubble_pressure_impl(model::ActivityModel,T,x,method::ActivityBubblePressure)
     sat = saturation_pressure.(model.puremodel,T)
@@ -79,8 +81,10 @@ function bubble_pressure_impl(model::ActivityModel,T,x,method::ActivityBubblePre
     return (p,vl,vv,y)
 end
 
-function bubble_temperature(model::ActivityModel,T,x)
-    bubble_temperature(model,T,x,ActivityBubbleTemperature(gas_fug = false, poynting = false))
+function init_preferred_method(method::typeof(bubble_temperature),model::ActivityModel,kwargs)
+    gas_fug = get(kwargs,gas_fug,false)
+    poynting = get(poynting,gas_fug,false)
+    return ActivityBubbleTemperature(;gas_fug,poynting,kwargs...)
 end
 
 function bubble_temperature(model::ActivityModel, T, x, method::BubblePointMethod)

--- a/src/models/Activity/methods/dew_point.jl
+++ b/src/models/Activity/methods/dew_point.jl
@@ -1,6 +1,6 @@
 function init_preferred_method(method::typeof(dew_pressure),model::ActivityModel,kwargs)
-    gas_fug = get(kwargs,gas_fug,false)
-    poynting = get(poynting,gas_fug,false)
+    gas_fug = get(kwargs,:gas_fug,false)
+    poynting = get(kwargs,:poynting,false)
     return ActivityDewPressure(;gas_fug,poynting,kwargs...)
 end
 
@@ -80,8 +80,8 @@ function dew_pressure_impl(model::ActivityModel,T,y,method::ActivityDewPressure)
 end
 
 function init_preferred_method(method::typeof(dew_temperature),model::ActivityModel,kwargs)
-    gas_fug = get(kwargs,gas_fug,false)
-    poynting = get(poynting,gas_fug,false)
+    gas_fug = get(kwargs,:gas_fug,false)
+    poynting = get(kwargs,:poynting,false)
     return ActivityDewTemperature(;gas_fug,poynting,kwargs...)
 end
 

--- a/src/models/Activity/methods/dew_point.jl
+++ b/src/models/Activity/methods/dew_point.jl
@@ -82,7 +82,7 @@ end
 function init_preferred_method(method::typeof(dew_temperature),model::ActivityModel,kwargs)
     gas_fug = get(kwargs,gas_fug,false)
     poynting = get(poynting,gas_fug,false)
-    return ActivityDewPressure(;gas_fug,poynting,kwargs...)
+    return ActivityDewTemperature(;gas_fug,poynting,kwargs...)
 end
 
 function dew_temperature(model::ActivityModel, T, x, method::DewPointMethod)
@@ -114,8 +114,6 @@ function dew_temperature_impl(model::ActivityModel,p,y,method::ActivityDewTemper
     vl = volume(pure.model,p,T,x,phase = :l)
     vv = volume(pure.model,p,T,y,phase = :v)
     return (T,vl,vv,x)
-    #p,vl,vv,y = bubble_pressure(model,T,x,ActivityBubblePressure(gas_fug = method.gas_fug,poynting = method.poynting))
-    #return (T,vl,vv,y)
 end
 
 function Obj_dew_temperature(F,model::ActivityModel,p,y,_x,T)

--- a/src/models/Activity/methods/dew_point.jl
+++ b/src/models/Activity/methods/dew_point.jl
@@ -1,5 +1,7 @@
-function dew_pressure(model::ActivityModel,T,x)
-    dew_pressure(model,T,x,ActivityDewPressure(gas_fug = false, poynting = false))
+function init_preferred_method(method::typeof(dew_pressure),model::ActivityModel,kwargs)
+    gas_fug = get(kwargs,gas_fug,false)
+    poynting = get(poynting,gas_fug,false)
+    return ActivityDewPressure(;gas_fug,poynting,kwargs...)
 end
 
 function dew_pressure(model::ActivityModel, T, y, method::DewPointMethod)
@@ -77,8 +79,10 @@ function dew_pressure_impl(model::ActivityModel,T,y,method::ActivityDewPressure)
     return (p,vl,vv,x)
 end
 
-function dew_temperature(model::ActivityModel,T,x)
-    dew_temperature(model,T,x,ActivityDewTemperature(gas_fug = false, poynting = false))
+function init_preferred_method(method::typeof(dew_temperature),model::ActivityModel,kwargs)
+    gas_fug = get(kwargs,gas_fug,false)
+    poynting = get(poynting,gas_fug,false)
+    return ActivityDewPressure(;gas_fug,poynting,kwargs...)
 end
 
 function dew_temperature(model::ActivityModel, T, x, method::DewPointMethod)

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -101,13 +101,12 @@ function volume_impl(model::CompositeModel,p,T,z,phase=:unknown,threaded=false,v
     end
 end
 
-function saturation_pressure(model::CompositeModel,T::Real)
-    if model.saturation isa SaturationModel
-        method = SaturationCorrelation()
-    else
-        method = ChemPotVSaturation()
-    end
-    return saturation_pressure(model,T,method)
+function init_preferred_method(method::typeof(saturation_pressure),model::SaturationModel,kwargs)
+    return init_preferred_method(saturation_pressure,model.saturation,kwargs)
+end
+
+function init_preferred_method(method::typeof(saturation_temperature),model::SaturationModel,kwargs)
+    return init_preferred_method(saturation_temperature,model.saturation,kwargs)
 end
 
 function saturation_pressure(model::CompositeModel,T,method::SaturationMethod)
@@ -120,7 +119,7 @@ function saturation_pressure(model::CompositeModel,T,method::SaturationMethod)
     #if psat fails, there are two options:
     #1- over critical point -> nan nan nan
     #2- saturation failed -> nan nan nan
-    else 
+    else
         return nan,nan,nan
     end
 end

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -144,6 +144,10 @@ function saturation_temperature(model::CompositeModel,p,method::SaturationMethod
 end
 
 #Michelsen TPFlash and rachford rice tpflash support
+function init_preferred_method(method::typeof(tp_flash),model::CompositeModel,kwargs)
+    return RRTPFlash(;kwargs...)
+end
+
 __tpflash_cache_model(model::CompositeModel,p,T,z) = PTFlashWrapper(model,T)
 
 function PTFlashWrapper(model::CompositeModel,T::Number) 

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -101,11 +101,11 @@ function volume_impl(model::CompositeModel,p,T,z,phase=:unknown,threaded=false,v
     end
 end
 
-function init_preferred_method(method::typeof(saturation_pressure),model::SaturationModel,kwargs)
+function init_preferred_method(method::typeof(saturation_pressure),model::CompositeModel,kwargs)
     return init_preferred_method(saturation_pressure,model.saturation,kwargs)
 end
 
-function init_preferred_method(method::typeof(saturation_temperature),model::SaturationModel,kwargs)
+function init_preferred_method(method::typeof(saturation_temperature),model::CompositeModel,kwargs)
     return init_preferred_method(saturation_temperature,model.saturation,kwargs)
 end
 

--- a/src/models/CompositeModel/SaturationModel/SaturationModel.jl
+++ b/src/models/CompositeModel/SaturationModel/SaturationModel.jl
@@ -12,16 +12,12 @@ saturation method used for dispatch on saturation correlations.
 """
 struct SaturationCorrelation <: SaturationMethod end
 
-function saturation_pressure(model::SaturationModel,T,method::SaturationMethod)
-    single_component_check(saturation_pressure,model)
-    T = T*(T/T)
-    return saturation_pressure_impl(model,T,SaturationCorrelation())
+function init_preferred_method(method::typeof(saturation_pressure),model::SaturationModel,kwargs)
+    return SaturationCorrelation()
 end
 
-function saturation_temperature(model::SaturationModel,p,method::SaturationMethod)
-    single_component_check(saturation_temperature,model)
-    p = p*(p/p)
-    return saturation_temperature_impl(model,p,SaturationCorrelation())
+function init_preferred_method(method::typeof(saturation_temperature),model::SaturationModel,kwargs)
+    return SaturationCorrelation()
 end
  
 function saturation_temperature_impl(model::SaturationModel,p,method::SaturationCorrelation)
@@ -39,16 +35,6 @@ function saturation_temperature_impl(model::SaturationModel,p,method::Saturation
     return sol,nan,nan
 end
 
-#=
-    tc = temperature(model,CriticalPoint())
-    pc = pressure(model,CriticalPoint())
-    t7 = 0.7*tc
-    p7 = pressure_impl(QuickStates.sat_t(),model,t7)
-    
-    h = 2.3333333333333335*log(pc/p7)
-    return 1/(1-log(p/pc)/h)*tc
-end
-=#
 eos(model,V,T,z=SA[1.0]) = not_eos_error(model)
 
 include("LeeKeslerSat/LeeKeslerSat.jl")


### PR DESCRIPTION
we now call a new function `init_preferred_method(method,model,kwargs)` to initialize a method. this helps specially in the cases where we need to define another methods for specific models (activity, composite models), while not interfering with the default args, and even expanding those. julia kwarg handling has improved, so using kwargs does not cause performance penalties like before. now we can do:
```
saturation_pressure(model,T,vl = 1.8e-5,vv = 0.03) #init_preferred_method(saturation_pressure,model::EoSModel,kwargs) = ChemPotVSaturation(;kwargs...)

tp_flash(model,p,T,z,equilibrium = :vle) #dispatch to MichelsenTPFlash
tp_flash(model,p,T,z) DETPFlash
tp_flash(activity_model,p,T,z) #RRTPFlash
tp_flash(activity_model,p,T,z,equilibrium = :vle) #RRTPFlash
```
all this while not touching any methods.
should solve "bubble_temperature no longer takes T0 as an initial guess for activity coefficient models" (#173)