### PR TITLE
Fix detection of real cubic roots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Clapeyron"
 uuid = "7c7805af-46cc-48c9-995b-ed0ed2dc909a"
 authors = ["Hon Wa Yew <yewhonwa@gmail.com>", "Pierre Walker <pwalker@mit.edu>", "Andrés Riedemann <andres.riedemann@gmail.com>"]
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -215,24 +215,14 @@ function crit_pure_tp(model::ABCCubicModel)
 end
 
 function volume_impl(model::ABCubicModel,p,T,z=SA[1.0],phase=:unknown,threaded=false,vol0=nothing)
-    lb_v   =lb_volume(model,z)
+    lb_v = lb_volume(model,z)
     if iszero(p)
         vl,_ = zero_pressure_impl(model,T,z)
         return vl
     end
     nRTp = sum(z)*R̄*T/p
     _poly,c̄ = cubic_poly(model,p,T,z)
-    sols = Solvers.roots3(_poly)
-    function imagfilter(x)
-        absx = abs(imag(x))
-        return absx < 8 * eps(typeof(absx))
-    end
-    x1, x2, x3 = sols
-    sols = (x1, x2, x3)
-    xx = (x1, x2, x3)
-    isreal = imagfilter.(xx)
-    vvv = extrema(real.(xx))
-    zl,zg = vvv
+    num_isreal, zl, zg = Solvers.real_roots3(_poly)
     vvl,vvg = nRTp*zl,nRTp*zg
     #err() = @error("model $model Failed to converge to a volume root at pressure p = $p [Pa], T = $T [K] and compositions = $z")
     if !isfinite(vvl) && !isfinite(vvg) && phase != :unknown
@@ -241,19 +231,12 @@ function volume_impl(model::ABCubicModel,p,T,z=SA[1.0],phase=:unknown,threaded=f
         #isnan(v) && err()
         return v
     end
-    if sum(isreal) == 3 #3 roots
+    if num_isreal == 3 # 3 real roots
         vg = vvg
         _vl = vvl
         vl = ifelse(_vl > lb_v, _vl, vg) #catch case where solution is unphysical
-    elseif sum(isreal) == 1
-        i = findfirst(imagfilter, sols)::Int
-        vl = real(sols[i]) * nRTp
-        vg = real(sols[i]) * nRTp
-    elseif sum(isreal) == 0
-        V0 = x0_volume(model, p, T, z; phase)
-        v = _volume_compress(model, p, T, z, V0)
-        #isnan(v) && err()
-        return v
+    else # 1 real root (or 2 with the second one degenerate)
+        vg = vl = zl * nRTp
     end
 
     function gibbs(v)

--- a/test/test_methods_api.jl
+++ b/test/test_methods_api.jl
@@ -435,7 +435,8 @@ end
         T = 202.694
         v0 = [-4.136285855713797, -4.131888756537859, 0.9673991775701574, 0.014192499147585259, 0.014746430039492817, 0.003661893242764558]
         model = PCSAFT(["methane","butane","isobutane","pentane"])
-        @test_broken bubble_pressure(model,T,x;v0 = v0)[1] ≈ 5.913118531569793e6 rtol = 1e-4
+        # @test_broken bubble_pressure(model,T,x;v0 = v0)[1] ≈ 5.913118531569793e6 rtol = 1e-4
+        # FIXME: The test does not yield the same value depending on the OS and the julia version
     end
 end
 

--- a/test/test_methods_eos.jl
+++ b/test/test_methods_eos.jl
@@ -298,6 +298,13 @@ end
     @test vc/system.params.Vc[1] ≈ 1.168 rtol = 1e-4 #if Zc_exp < 0.29, this should hold, by definition
 end
 
+@testset "EPPR78, single component" begin
+    system = EPPR78(["carbon dioxide"])
+    T = 400u"K"
+    @test Clapeyron.volume(system, 3311.0u"bar", T) ≈ 3.363139140634349e-5u"m^3"
+    @test Clapeyron.molar_density(system, 3363.1u"bar", T) ≈ 29810.118127751106u"mol*m^-3"
+end
+
 @testset "Cubic methods, multi-components" begin
     system = RK(["ethane","undecane"])
     p = 1e7

--- a/test/test_solvers.jl
+++ b/test/test_solvers.jl
@@ -43,7 +43,13 @@ end
         #@test [@inferred(SOL.roots3(SA[-6im, -(3 + 4im), 2im-2, 1.0]))...] ≈ [3, -2im, -1]
         @test @inferred(SOL.roots3(1.0, -3.0, 3.0, -1.0)) ≈ [1, 1, 1]
         @test @inferred(SOL.roots3([1.0, -3.0, 3.0, -1.0])) ≈ [1, 1, 1]
+        @test @inferred(SOL.real_roots3((0.4179831841886642, -16.86256511617483, 1.6508521434627874, 1.0))) == (3, -5.0238891763914015, 3.3481880327202824)
+        @test @inferred(SOL.real_roots3(0.7336510424849684, -17.464843881306653, 1.6925644348171853, 1.0)) == (3, -5.126952070514365, 3.392203575902995)
+        @test @inferred(SOL.real_roots3(-1, 3, -3, 1)) == (2, 1.0, 1.0) # triply degenerate root
+        @test collect(SOL.real_roots3(1, -1, -1, 1)) ≈ [2, -1.0, 1.0] # one doubly degenerate
+        @test SOL.real_roots3(1, 0, 1, 2) == (1, -1.0, -1.0) # only one real root
     end
+
     # A difficult MCP.
     #
     # Presented in Miranda and Fackler (2002): "Applied Computational Economics and


### PR DESCRIPTION
Thank you for this great package!

I encountered the following behaviour when looking at CO2 with a cubic equation of state:
```julia
julia> system = EPPR78(["carbon dioxide"]);

julia> Clapeyron.volume(system , 3311.0u"bar", 400.0u"K")
ERROR: UndefVarError: `vl` not defined
Stacktrace:
 [1] volume_impl(model::PR{…}, p::Float64, T::Float64, z::SVector{…}, phase::Symbol, threaded::Bool, vol0::Nothing)
   @ Clapeyron ~/.julia/packages/Clapeyron/JJGLA/src/models/cubic/equations.jl:269
 [2] volume(model::PR{…}, p::Float64, T::Float64, z::SVector{…}; phase::Symbol, threaded::Bool, vol0::Nothing)
   @ Clapeyron ~/.julia/packages/Clapeyron/JJGLA/src/methods/property_solvers/volume.jl:118 [inlined]
 [3] volume(model::PR{…}, p::Quantity{…}, T::Quantity{…}, z::SVector{…}; phase::Symbol, output::Unitful.FreeUnits{…})
   @ Clapeyron ~/.julia/packages/Clapeyron/JJGLA/src/methods/unitful_methods.jl:58 [inlined]
 [4] volume(model::PR{…}, p::Quantity{…}, T::Quantity{…}, z::SVector{…})
   @ Clapeyron ~/.julia/packages/Clapeyron/JJGLA/src/methods/unitful_methods.jl:55 [inlined]
 [5] top-level scope
   @ REPL[3]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Arguably worse, for a slightly different pressure, there is no error but the answer is obviously wrong (the volume is negative):

```julia
julia> Clapeyron.volume(system , 3363.1u"bar", 400.0u"K")
-5.070066466695018e-5 m^3
```

After investigating, it turns out that this is due to a faulty heuristic used to determine which roots of a cubic polynomial are real. This PR implements a cleaner heuristic that checks the value of the polynomial between the real parts of the roots, and compares the sign of these values to determine more precisely whether the roots are real. This yields more satisfying answers:
```julia
julia> Clapeyron.volume(system , 3311.0u"bar", 400.0u"K")
3.363139140634349e-5 m^3

julia> Clapeyron.volume(system , 3363.1u"bar", 400.0u"K")
3.3545657072357283e-5 m^3
```

~And as a bonus, it seems that this bugfix incidentally makes the test for https://github.com/ClapeyronThermo/Clapeyron.jl/issues/172 pass (whereas it was marked as `@test_broken`).~