### PR TITLE
Add Unitful support to all documented bulk properties

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -38,7 +38,7 @@
 # v0.5.3
 
 ## New Features
-- Databases were standarized according to CAS. almost all components present in Clapeyron.jl databases are present in `@DB/properties/identifiers.csv`.
+- Databases were standardized according to CAS. almost all components present in Clapeyron.jl databases are present in `@DB/properties/identifiers.csv`.
 - COSMOSAC-2002 (`COSMOSAC02`),COSMOSAC-2010 (`COSMOSAC10`) and COSMOSAC-dispersion (`COSMOSACdsp`) can now read files from the NIST database found at https://github.com/usnistgov/COSMOSAC . to use those parameters, pass the keyword `use_nist_database = true`
 - New model: doubly association perturbation theory (`DAPT`)
 - New model: PCSAFT with association dependent hard sphere diameter (`ADPCSAFT`)

--- a/docs/src/properties/bulk.md
+++ b/docs/src/properties/bulk.md
@@ -26,20 +26,20 @@ Clapeyron.pip
 
 In general almost all bulk properties follow the pattern:
 ```julia
-function property(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function property(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true)
+    V = volume(model, p, T, z; phase, threaded)
     return VT_property(model,V,T,z)
 end
 ```
 So, you can calculate the property with Volume-Temperature variables by calling `VT_property(model,V,T,z).`
-Another way to do this is by using units,provided by `Unitful.jl`:
+Another way to do this is by using units, provided by `Unitful.jl`:
 ```julia
 using Unitful
 r = 18u"kg/m^3"
 T = 373.15"K"
-prop = helholtz_free_energy(model,r,T,z,output = u"kJ")
+prop = helmholtz_free_energy(model,r,T,z,output = u"kJ")
 ```
-Where `r` could be any molar or mass density, molar or mass volume, total volume or pressure. it also supports mass and mol amounts defined as units for the composition (`z`) If no units are provided for the composition, they will be considered moles.
+Where `r` could be any molar or mass density, molar or mass volume, total volume or pressure. It also supports mass and mol amounts defined as units for the composition (`z`) If no units are provided for the composition, they will be considered moles.
 
 ### Methods that require first order VT derivatives
 ```@docs

--- a/docs/src/properties/bulk.md
+++ b/docs/src/properties/bulk.md
@@ -66,7 +66,7 @@ Clapeyron.isobaric_expansivity
 Clapeyron.joule_thomson_coefficient
 ```
 
-### Methods that first order composition derivatives
+### Methods that require first order composition derivatives
 ```@docs
 Clapeyron.chemical_potential
 Clapeyron.chemical_potential_res

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -104,9 +104,12 @@ function C.pressure(model::EoSModel, v::__VolumeKind, T::Unitful.Temperature, z=
 end
 
 for (fn,unit) in [
+    (:chemical_potential, u"J/mol"),
+    (:chemical_potential_res, u"J/mol"),
     (:compressibility_factor, NoUnits),
     (:enthalpy, u"J"),
     (:entropy, u"J/K"),
+    (:entropy_res, u"J/K"),
     (:gibbs_free_energy, u"J"),
     (:helmholtz_free_energy, u"J"),
     (:internal_energy, u"J"),
@@ -138,13 +141,12 @@ for (fn,unit) in [
     end
 end
 
-function C.volume(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=u"m^3", threaded=true)
+function C.volume(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=u"m^3", threaded=true, vol0=nothing)
     st = standarize(model,p,T,z)
     _p,_T,_z = state_to_pt(model,st)
-    res = volume(model, _p, _T, _z; phase, threaded)*u"m^3"
+    res = volume(model, _p, _T, _z; phase, threaded, vol0)*u"m^3"
     return uconvert(output, res)
 end
-
 
 #second_virial_coefficient
 function C.second_virial_coefficient(model::EoSModel, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
@@ -186,6 +188,20 @@ function C.saturation_pressure(model::EoSModel, T::Unitful.Temperature; output=(
     _v_l = uconvert(output[2],v_l*u"m^3")
     _v_v = uconvert(output[3],v_v*u"m^3")
     return (_P_sat,_v_l,_v_v)
+end
+
+function C.fugacity_coefficient(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, threaded=true)
+    st = standarize(model,p,T,z)
+    _p,_T,_z = state_to_pt(model,st)
+    res = C.fugacity_coefficient(model, _p, _T, _z; phase, threaded)
+    return res
+end
+
+function C.volume_virial(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
+    st = standarize(model,p,T,z)
+    _p,_T,_z = state_to_pt(model,st)
+    res = C.volume_virial(model, _p, _T, _z)*u"m^3"
+    return uconvert(output, res)
 end
 
 end #module

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -129,14 +129,14 @@ for (fn,unit) in [
             st = standarize(model,v,T,z)
             _v,_T,_z = state_to_vt(model,st)
             res = C.$VT_fn(model, _v, _T,_z)*$unit
-            return uconvert(output, res)
+            return uconvert.(output, res)
         end
 
         function C.$fn(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=$unit, threaded=true)
             st = standarize(model,p,T,z)
             _p,_T,_z = state_to_pt(model,st)
             res = C.$fn(model, _p, _T, _z; phase, threaded)*($unit)
-            return uconvert(output, res)
+            return uconvert.(output, res)
         end
     end
 end

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -204,7 +204,7 @@ function C.enthalpy_vap(model::EoSModel, T::Unitful.Temperature; output=u"J")
     return uconvert(output,res)
 end
 
-function C.saturation_pressure(model::EoSModel, T::Unitful.Temperature; output=[u"Pa", u"m^3", u"m^3"])
+function C.saturation_pressure(model::EoSModel, T::Unitful.Temperature; output=(u"Pa", u"m^3", u"m^3"))
     st = standarize(model,-1,T,C.SA[1.0])
     _,_T,_ = state_to_pt(model,st)
     (P_sat, v_l, v_v) = saturation_pressure(model,_T)

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -103,35 +103,23 @@ function C.pressure(model::EoSModel, v::__VolumeKind, T::Unitful.Temperature, z=
     return uconvert(output, res)
 end
 
-for (fn,unit) in Iterators.zip(
-    [:enthalpy,
-    :entropy,
-    :internal_energy,
-    :gibbs_free_energy,
-    :helmholtz_free_energy,
-    :isochoric_heat_capacity,
-    :isobaric_heat_capacity,
-    :isothermal_compressibility,
-    :isentropic_compressibility,
-    :speed_of_sound,
-    :isobaric_expansivity,
-    :joule_thomson_coefficient,
-    :mass_density,
-    :molar_density],
-    [u"J",
-    u"J/K",
-    u"J",
-    u"J",
-    u"J",
-    u"J/K",
-    u"J/K",
-    u"Pa^-1",
-    u"Pa^-1",
-    u"m/s",
-    u"K^-1",
-    u"K/Pa",
-    u"kg/m^3",
-    u"mol/m^3"])
+for (fn,unit) in [
+    (:compressibility_factor, NoUnits),
+    (:enthalpy, u"J"),
+    (:entropy, u"J/K"),
+    (:gibbs_free_energy, u"J"),
+    (:helmholtz_free_energy, u"J"),
+    (:internal_energy, u"J"),
+    (:isentropic_compressibility, u"Pa^-1"),
+    (:isobaric_expansivity, u"K^-1"),
+    (:isobaric_heat_capacity, u"J/K"),
+    (:isochoric_heat_capacity, u"J/K"),
+    (:isothermal_compressibility, u"Pa^-1"),
+    (:joule_thomson_coefficient, u"K/Pa"),
+    (:mass_density, u"kg/m^3"),
+    (:molar_density, u"mol/m^3"),
+    (:speed_of_sound, u"m/s"),
+    ]
     VT_fn = Symbol(:VT_,fn)
     @eval begin
         function C.$fn(model::EoSModel, v::__VolumeKind, T::Unitful.Temperature, z=SA[1.]; output=$unit)
@@ -157,20 +145,6 @@ function C.volume(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, 
     return uconvert(output, res)
 end
 
-#compressibility_factor
-function C.compressibility_factor(model::EoSModel, v::__VolumeKind, T::Unitful.Temperature, z=SA[1.])
-    st = standarize(model,v,T,z)
-    _v,_T,_z = state_to_vt(model,st)
-    res = C.VT_compressibility_factor(model, _v, _T,_z)
-    return res
-end
-
-function C.compressibility_factor(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, threaded=true)
-    st = standarize(model,p,T,z)
-    _p,_T,_z = state_to_pt(model,st)
-    res = compressibility_factor(model, _p, _T, _z; phase, threaded)
-    return res
-end
 
 #second_virial_coefficient
 function C.second_virial_coefficient(model::EoSModel, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -217,14 +217,14 @@ function C.x0_psat(model::EoSModel, T::Unitful.Temperature, Tc::Unitful.Temperat
 end
 
 # x0_psat interface
-for modeltype in (:EoSModel, :SingleFluid, :MultiFluid, :CompositeModel)
+for modeltype in (:EoSModel, :(C.SingleFluid), :(C.MultiFluid), :(C.CompositeModel))
     @eval function C.x0_psat(model::($modeltype), T::Unitful.Temperature, crit=nothing; output=u"Pa")
         uconvert(output, C.x0_psat(model, standardize(T, 1u"K"), crit)*u"Pa")
     end
 end
 
 # x0_sat_pure using z
-for modeltype in (:EoSModel, :SingleFluid, :ExtendedCorrespondingStates)
+for modeltype in (:EoSModel, :(C.SingleFluid), :(C.ExtendedCorrespondingStates))
     @eval function C.x0_sat_pure(model::($modeltype), T::Unitful.Temperature, z=SA[1.0]; output=(u"m^3", u"m^3"))
         st = standardize(model,-1,T,z)
         _,_T,_z = state_to_pt(model,st)
@@ -235,7 +235,7 @@ for modeltype in (:EoSModel, :SingleFluid, :ExtendedCorrespondingStates)
     end
 end
 # x0_sat_pure without z
-for modeltype in (:CompositeModel, :MultiFluid, :LJRef, :(Clapeyron.ActivityModel), :(Clapeyron.ABCubicModel))
+for modeltype in (:(C.CompositeModel), :(C.MultiFluid), :(C.LJRef), :(C.ActivityModel), :(C.ABCubicModel))
     @eval function C.x0_sat_pure(model::($modeltype), T::Unitful.Temperature; output=(u"m^3", u"m^3"))
         v_l, v_v = C.x0_sat_pure(model, standardize(T, 1u"K"))
         _v_l = uconvert(output[1],v_l*u"m^3")
@@ -245,7 +245,7 @@ for modeltype in (:CompositeModel, :MultiFluid, :LJRef, :(Clapeyron.ActivityMode
 end
 
 # x0_saturation_temperature
-for modeltype in (:EoSModel, :SingleFluid, :MultiFluid)
+for modeltype in (:EoSModel, :(C.SingleFluid), :(C.MultiFluid))
     @eval function C.x0_saturation_temperature(model::($modeltype), p::Unitful.Pressure; output=(u"K", u"m^3", u"m^3"))
         (T_sat, v_l, v_v) = C.x0_saturation_temperature(model, standardize(p, nothing))
         _T_sat = uconvert(output[1],T_sat*u"K")
@@ -263,7 +263,7 @@ function C.x0_volume(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperatur
 end
 
 # x0_volume_gas
-for modeltype in (:EoSModel, :MultiFluid, :SanchezLacombe, :(Clapeyron.DAPTModel))
+for modeltype in (:EoSModel, :(C.MultiFluid), :(C.SanchezLacombe), :(C.DAPTModel))
     @eval function C.x0_volume_gas(model::($modeltype), p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
         st = standardize(model,p,T,z)
         _p,_T,_z = state_to_pt(model,st)
@@ -273,7 +273,7 @@ for modeltype in (:EoSModel, :MultiFluid, :SanchezLacombe, :(Clapeyron.DAPTModel
 end
 
 # x0_volume_liquid with a default value for z
-for modeltype in (:SingleFluid, :ExtendedCorrespondingStates, :(Clapeyron.ActivityModel), :(Clapeyron.AnalyticalSLVModel))
+for modeltype in (:(C.SingleFluid), :(C.ExtendedCorrespondingStates), :(C.ActivityModel), :(C.AnalyticalSLVModel))
     @eval function C.x0_volume_liquid(model::($modeltype), T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
         st = standardize(model,-1,T,z)
         _,_T,_z = state_to_pt(model,st)
@@ -283,9 +283,9 @@ for modeltype in (:SingleFluid, :ExtendedCorrespondingStates, :(Clapeyron.Activi
 end
 
 # x0_volume_liquid without a default value for z
-for modeltype in (:EoSModel, :MultiFluid, :SanchezLacombe, :(Clapeyron.SAFTVRQMieModel),
-                  :(Clapeyron.softSAFTModel), :(Clapeyron.PeTSModel), :(Clapeyron.SAFTgammaMieModel),
-                  :(Clapeyron.SAFTVRMieModel), :(Clapeyron.BACKSAFTModel))
+for modeltype in (:EoSModel, :(C.MultiFluid), :(C.SanchezLacombe), :(C.SAFTVRQMieModel),
+                  :(C.softSAFTModel), :(C.PeTSModel), :(C.SAFTgammaMieModel),
+                  :(C.SAFTVRMieModel), :(C.BACKSAFTModel))
     @eval function C.x0_volume_liquid(model::($modeltype), T::Unitful.Temperature, z; output=u"m^3")
         st = standardize(model,-1,T,z)
         _,_T,_z = state_to_pt(model,st)
@@ -295,7 +295,7 @@ for modeltype in (:EoSModel, :MultiFluid, :SanchezLacombe, :(Clapeyron.SAFTVRQMi
 end
 
 # x0_volume_solid with a default value for z
-function C.x0_volume_solid(model::Clapeyron.AnalyticalSLVModel, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
+function C.x0_volume_solid(model::C.AnalyticalSLVModel, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
     st = standardize(model,-1,T,z)
     _,_T,_z = state_to_pt(model,st)
     res = C.x0_volume_solid(model, _T, _z)*u"m^3"

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -141,19 +141,19 @@ for (fn,unit) in Iterators.zip(
             return uconvert(output, res)
         end
 
-        function C.$fn(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=$unit)
+        function C.$fn(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=$unit, threaded=true)
             st = standarize(model,p,T,z)
             _p,_T,_z = state_to_pt(model,st)
-            res = C.$fn(model, _p, _T, _z; phase=phase)*($unit)
+            res = C.$fn(model, _p, _T, _z; phase, threaded)*($unit)
             return uconvert(output, res)
         end
     end
 end
 
-function C.volume(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=u"m^3")
+function C.volume(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, output=u"m^3", threaded=true)
     st = standarize(model,p,T,z)
     _p,_T,_z = state_to_pt(model,st)
-    res = volume(model, _p, _T, _z; phase=phase)*u"m^3"
+    res = volume(model, _p, _T, _z; phase, threaded)*u"m^3"
     return uconvert(output, res)
 end
 
@@ -165,15 +165,15 @@ function C.compressibility_factor(model::EoSModel, v::__VolumeKind, T::Unitful.T
     return res
 end
 
-function C.compressibility_factor(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown)
+function C.compressibility_factor(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, threaded=true)
     st = standarize(model,p,T,z)
     _p,_T,_z = state_to_pt(model,st)
-    res = compressibility_factor(model, _p, _T, _z; phase=phase)
+    res = compressibility_factor(model, _p, _T, _z; phase, threaded)
     return res
 end
 
 #second_virial_coefficient
-function C.second_virial_coefficient(model::EoSModel, T::Unitful.Temperature, z=SA[1.];output=u"m^3")
+function C.second_virial_coefficient(model::EoSModel, T::Unitful.Temperature, z=SA[1.]; output=u"m^3")
     st = standarize(model,-1,T,z)
     _,_T,_z = state_to_pt(model,st)
     res = second_virial_coefficient(model, _T,_z)*u"m^3"

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -43,7 +43,7 @@ function mw(model)
 end
 #handle pressure/volume/temp
 standarize(x::Number,st::Nothing) = x #default
-standarize(x::Unitful.Pressure,st::Nothing) = uconvert(u"Pa",x)
+standarize(x::Unitful.Pressure,st::Nothing) = ustrip(u"Pa",x)
 standarize(x::__VolumeKind,st::Nothing) = upreferred(x)
 standarize(x::Number,st::Unitful.Temperature) = x #default
 standarize(x::Unitful.Temperature,st::Unitful.Temperature) = ustrip(u"K",x)
@@ -76,8 +76,6 @@ total_volume(model,x::__MolDensity,z) = C.molecular_weight(model,z) / ustrip(x)
 total_volume(model,x::__MassVolume,z) = ustrip(x) * mass(model,z)
 total_volume(model,x::__MassDensity,z) = mass(model,z) / ustrip(x)
 
-_pressure(x::Number) = x
-_pressure(x::Unitful.Pressure) = ustrip(x)
 
 function state_to_vt(model,st::StdState)
     V = total_volume(model,st.x,st.z)
@@ -87,7 +85,7 @@ function state_to_vt(model,st::StdState)
 end
 
 function state_to_pt(model,st::StdState)
-    p = _pressure(st.x)
+    p = st.x
     T = st.T
     z = st.z
     return p,T,z

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -27,9 +27,6 @@ function standarize(model,x,T,z)
     return StdState(xs,ts,zs)
 end
 
-#utility func
-_u0(x::T,val::V) where {T,V} = ustrip(uconvert(x,val))
-
 function mw(model)
     if C.has_groups(model)
         n = length(model)
@@ -49,17 +46,17 @@ standarize(x::Number,st::Nothing) = x #default
 standarize(x::Unitful.Pressure,st::Nothing) = uconvert(u"Pa",x)
 standarize(x::__VolumeKind,st::Nothing) = upreferred(x)
 standarize(x::Number,st::Unitful.Temperature) = x #default
-standarize(x::Unitful.Temperature,st::Unitful.Temperature) = _u0(u"K",x)
+standarize(x::Unitful.Temperature,st::Unitful.Temperature) = ustrip(u"K",x)
 
 #handle vector of compounds
 standarize(model,x::Number,st::Unitful.Amount) = C.SA[x]
-standarize(model,x::Unitful.Amount,st::Unitful.Amount) = C.SA[_u0(u"mol",x)]
+standarize(model,x::Unitful.Amount,st::Unitful.Amount) = C.SA[ustrip(u"mol",x)]
 standarize(model,x::AbstractVector{<:Number},st::Unitful.Amount) = x
-standarize(model,x::AbstractVector{<:Unitful.Amount},st::Unitful.Amount) = _u0.(u"mol",x)
+standarize(model,x::AbstractVector{<:Unitful.Amount},st::Unitful.Amount) = ustrip.(u"mol",x)
 #mass forms
-standarize(model,x::Unitful.Mass,st::Unitful.Amount) = C.SA[1000*_u0(u"kg",x)/mw(model)[1]]
+standarize(model,x::Unitful.Mass,st::Unitful.Amount) = C.SA[1000*ustrip(u"kg",x)/mw(model)[1]]
 function standarize(model,x::AbstractVector{<:Unitful.Mass},st::Unitful.Amount)
-    return map(y -> 1000*_u0(u"kg",y[1])/y[2],zip(x,mw(model)))
+    return map(y -> 1000*ustrip(u"kg",y[1])/y[2],zip(x,mw(model)))
 end
 
 function mass(model,z)

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -207,6 +207,15 @@ function C.volume_virial(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temper
     return uconvert(output, res)
 end
 
+# resolve ambiguity
+function C.chemical_potential(model::(C.SolidHfusModel), p::Unitful.Pressure, T::Unitful.Temperature, z; output=u"J/mol")
+    st = standardize(model,p,T,z)
+    _p,_T,_z = state_to_pt(model,st)
+    res = C.chemical_potential(model, _p, _T, _z)*u"J/mol"
+    return uconvert.(output, res)
+end
+
+
 # x0_psat fallback method
 function C.x0_psat(model::EoSModel, T::Unitful.Temperature, Tc::Unitful.Temperature, Vc::__VolumeKind; output=u"Pa")
     st = standardize(model, Vc, T, SA[1.])

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -185,6 +185,14 @@ function C.saturation_pressure(model::EoSModel, T::Unitful.Temperature; output=(
     return (_P_sat,_v_l,_v_v)
 end
 
+function C.saturation_temperature(model::EoSModel, p::Unitful.Pressure; output=(u"K", u"m^3", u"m^3"))
+    (T_sat, v_l, v_v) = C.saturation_temperature(model, standarize(p, nothing))
+    _T_sat = uconvert(output[1],T_sat*u"K")
+    _v_l = uconvert(output[2],v_l*u"m^3")
+    _v_v = uconvert(output[3],v_v*u"m^3")
+    return (_T_sat,_v_l,_v_v)
+end
+
 function C.fugacity_coefficient(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temperature, z=SA[1.]; phase=:unknown, threaded=true)
     st = standarize(model,p,T,z)
     _p,_T,_z = state_to_pt(model,st)

--- a/ext/ClapeyronUnitfulExt.jl
+++ b/ext/ClapeyronUnitfulExt.jl
@@ -208,6 +208,12 @@ function C.volume_virial(model::EoSModel, p::Unitful.Pressure, T::Unitful.Temper
 end
 
 # resolve ambiguity
+function C.chemical_potential(model::(C.SolidHfusModel), v::__VolumeKind, T::Unitful.Temperature, z=SA[1.]; output=u"J/mol")
+    st = standardize(model,v,T,z)
+    _v,_T,_z = state_to_vt(model,st)
+    res = C.VT_chemical_potential(model, _v, _T,_z)*u"J/mol"
+    return uconvert.(output, res)
+end
 function C.chemical_potential(model::(C.SolidHfusModel), p::Unitful.Pressure, T::Unitful.Temperature, z; output=u"J/mol")
     st = standardize(model,p,T,z)
     _p,_T,_z = state_to_pt(model,st)

--- a/src/Clapeyron.jl
+++ b/src/Clapeyron.jl
@@ -91,13 +91,9 @@ include("utils/acceleration_ss.jl")
 #Clapeyron methods (AD, property solvers, etc)
 include("methods/methods.jl")
 
-#Unitful support, transition from dependency to ext
-if !isdefined(Base,:get_extension)
-    include("../ext/ClapeyronUnitfulExt.jl")
-end
 #=
 the dependency chain is the following:
-base --> database(params)  -|-> split_model --> methods -|-> models                     
+base --> database(params)  -|-> split_model --> methods -|-> models
                             |-> macros ------------------|
 =#
 
@@ -233,6 +229,12 @@ include("models/ECS/variants/SPUNG.jl")
 include("models/PeTS/PeTS.jl")
 include("models/UFTheory/UFTheory.jl")
 include("models/AnalyticalSLV/AnalyticalSLV.jl")
+
+#Unitful support, transition from dependency to ext
+if !isdefined(Base,:get_extension)
+    include("../ext/ClapeyronUnitfulExt.jl")
+end
+
 include("utils/misc.jl")
 
 include("estimation/estimation.jl")

--- a/src/database/database_rawparam.jl
+++ b/src/database/database_rawparam.jl
@@ -230,7 +230,7 @@ end
 
 function compile_assoc(name,components,raw::RawParam,site_strings,options)
     EMPTY_STR = ""
-    _ijab = standarize_comp_info(raw.component_info,components,site_strings)
+    _ijab = standardize_comp_info(raw.component_info,components,site_strings)
     unique_sitepairs = unique(raw.component_info)
     l = length(unique_sitepairs)
     unique_dict = Dict{NTuple{4,String},Int}(unique_sitepairs[i] => i for i in 1:l)
@@ -266,7 +266,7 @@ function compile_assoc(name,components,raw::CSVType,site_strings,options)
 end
 
 #Sort site tape, so that components are sorted by the input.
-function standarize_comp_info(component_info,components,site_strings)
+function standardize_comp_info(component_info,components,site_strings)
     ijab = Vector{Tuple{Int,Int,Int,Int}}(undef,length(component_info))
     l = length(components)
     for (i,val) ∈ pairs(component_info)

--- a/src/methods/pT.jl
+++ b/src/methods/pT.jl
@@ -156,14 +156,14 @@ end
 """
     isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
 
-Default units: `[J/T]`
-     
+Default units: `[J/K]`
+
 Calculates the isochoric heat capacity, defined as:
 
 ```julia
 Cv = -T * ∂²A/∂T²
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isochoric_heat_capacity(model,V,T,z)`.
 
 The keywords `phase` and `threaded` are passed to the volume solver.
@@ -179,14 +179,14 @@ end
 """
     isobaric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
 
-Default units: `[J/T]`
-   
+Default units: `[J/K]`
+
 Calculates the isobaric heat capacity, defined as:
 
 ```julia
 Cp =  -T*(∂²A/∂T² - (∂²A/∂V∂T)^2 / ∂²A/∂V²)
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isobaric_heat_capacity(model,V,T,z)`.
 
 The keywords `phase` and `threaded` are passed to the volume solver.

--- a/src/models/ideal/JobackIdeal.jl
+++ b/src/models/ideal/JobackIdeal.jl
@@ -1,6 +1,6 @@
 
 #TODO
-# - standarize chemical group notation to make it the same as SAFTgammaMie
+# - standardize chemical group notation to make it the same as SAFTgammaMie
 # - add a database of group Mw
 
 struct JobackIdealParam <: EoSParam

--- a/test/test_methods_api.jl
+++ b/test/test_methods_api.jl
@@ -42,6 +42,11 @@
     @test isothermal_compressibility(model31,1u"bar",50u"°C",output = u"bar^-1") ≈ 44.17306906730427e-6u"bar^-1" rtol = 1E-6
     #enthalpy of vaporization of water at 100 °C
     @test enthalpy_vap(model31,100u"°C",output = u"kJ") ≈ 40.64971775824767u"kJ" rtol = 1E-6
+
+    # consistency of the results with/without units
+    @test chemical_potential(BasicIdeal(), 1e6u"Pa", 300u"K") == chemical_potential(BasicIdeal(), 1e6, 300)*u"J/mol"
+    @test Clapeyron.x0_psat(model11, 100u"K") == Clapeyron.x0_psat(model11, 100)*u"Pa"
+    @test Clapeyron.x0_sat_pure(model11, 100u"K") == Clapeyron.x0_sat_pure(model11, 100).*(u"m^3",)
 end
 
 @testset "association" begin

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -195,6 +195,9 @@ end
     if Base.VERSION >= v"1.8" #for some reason, it segfaults on julia 1.6
         @testset "ambiguities" begin
             ambiguities = Test.detect_ambiguities(Clapeyron)
+            if !isempty(ambiguities)
+                foreach(display, ambiguities)
+            end
             @test length(ambiguities) == 0
         end
     end


### PR DESCRIPTION
The documentation states (at the bottom of [Basic usages](https://clapeyronthermo.github.io/Clapeyron.jl/dev/user_guide/basic_usage/)):
```
Clapeyron also supports physical units through the use of Unitful.jl.
[...]
This is only supported for bulk properties.
```

This PR makes this necessary condition sufficient as well, by implementing unit support for all [documented Bulk properties](https://clapeyronthermo.github.io/Clapeyron.jl/dev/properties/bulk/).

I only added a couple of tests, I don't know if this requires being extensive and adding one test per method.

If you plan on extending unit support to all single phase and multiphase properties as well, it might be worth writing a macro to automate some of that work, because adding each method individually in ClapeyronUnitfulExt.jl is not really manageable. It also leads to brittle code, because it's easy to miss reflecting a change in the Unitful extension if a method is updated in Clapeyron.