### PR TITLE
Remove Unitful from [deps]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 BlackBoxOptim = "^0.6.2"


### PR DESCRIPTION
`Unitful` is a weak dependency, not a strong one (it could be both, as in https://github.com/JuliaLang/julia/issues/50028, but that's not the case here), so it should not be in the [deps] section of the Project.toml.