### PR TITLE
Add vol0 keyword argument to bulk properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,9 +10,10 @@
 - New property: triple point. `triple_point(model::CompositeModel)`
 - `CompositeModel` was revamped to support more general equilibria. in particular it will be used to represent equilibria with Activity Models along with with Real Gases. As a result of these enhancements, `CompositeModel` now supports `bubble_pressure`,`bubble_temperature`,`dew_pressure`, and `dew_temperature`.
 - `DETPFlash` supports LLE equilibria with activity models
+- Bulk properties now accept a `vol0` initial point for the volume solver.
 
 ## Bug fixes
-- `SAFTVRMie` was allocating excesively because of unbound type parameter. 
+- `SAFTVRMie` was allocating excesively because of unbound type parameter.
 - typos in `pharmaPCSAFT`
 - `SanchezLacombe` didn't set `k` correctly when passed as `userlocations`
 - `CPA`, SAFT equation of state and other EoS that implement association,don't need to specify `bondvol` and `epsilon_assoc`, when using non-associating species.

--- a/docs/src/properties/bulk.md
+++ b/docs/src/properties/bulk.md
@@ -26,8 +26,8 @@ Clapeyron.pip
 
 In general almost all bulk properties follow the pattern:
 ```julia
-function property(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true)
-    V = volume(model, p, T, z; phase, threaded)
+function property(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_property(model,V,T,z)
 end
 ```

--- a/docs/src/user_guide/basic_usage.md
+++ b/docs/src/user_guide/basic_usage.md
@@ -252,13 +252,15 @@ The functions for the physical properties that we currently support are as follo
 
     The default value is `:unknown` where it will find both the vapour and liquid roots first and determine which has the lowest Gibbs free energy.
 
-  - `threaded`: This determines whether or not to run the vapour and liquid calculations in parallel or not and is only relevant for when the phases are unknown and non-cubic models. 
+  - `threaded`: This determines whether or not to run the vapour and liquid calculations in parallel or not and is only relevant for when the phases are unknown and non-cubic models.
 
-    ```
+    ```julia
     V = volume(model, p, T, z; threaded=false)
     ```
 
     The default value is `true`. This shouldn't change the results.
+
+  Most of the above functions also accept the `vol0` optional keyword argument, which specifies an initial guess for the [Clapeyron.volume](@ref) solver.
 
   Note that all of the above functions can be broadcast _i.e._ if `T` is an array, instead of a for loop, we can simply:
 

--- a/src/methods/pT.jl
+++ b/src/methods/pT.jl
@@ -1,5 +1,5 @@
 """
-    entropy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    entropy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J/K]`
 
@@ -10,15 +10,15 @@ S = -∂A/∂T
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_entropy(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function entropy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
-    return VT_entropy(model,V,T,z)
+function entropy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
+    return VT_entropy(model, V, T, z)
 end
 
 """
-    entropy_res(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    entropy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J/K]`
 
@@ -29,17 +29,17 @@ S = -∂Ares/∂T
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_entropy_res(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function entropy_res(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
-    return VT_entropy_res(model,V,T,z)
+function entropy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
+    return VT_entropy_res(model, V, T, z)
 end
 
 """
-    chemical_potential(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    chemical_potential(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
-Default units: `[J/mol]`    
+Default units: `[J/mol]`
 
 Calculates the chemical potential, defined as:
 
@@ -48,15 +48,15 @@ Calculates the chemical potential, defined as:
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_chemical_potential(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function chemical_potential(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function chemical_potential(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_chemical_potential(model,V,T,z)
 end
 
 """
-    chemical_potential_res(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    chemical_potential_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J/mol]`
 
@@ -67,15 +67,15 @@ Calculates the residual chemical potential, defined as:
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_chemical_potential_res(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function chemical_potential_res(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function chemical_potential_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_chemical_potential_res(model,V,T,z)
 end
 
 """
-    internal_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    internal_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
 
@@ -86,18 +86,18 @@ U = A - T * ∂A/∂T
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_internal_energy(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function internal_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function internal_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_internal_energy(model,V,T,z)
 end
 
 """
-    enthalpy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    enthalpy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
-     
+
 Calculates the enthalpy, defined as:
 
 ```julia
@@ -105,18 +105,18 @@ H = A - T * ∂A/∂T - V * ∂A/∂V
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_enthalpy(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function enthalpy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function enthalpy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_enthalpy(model,V,T,z)
 end
 
 """
-    gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
-     
+
 Calculates the gibbs free energy, defined as:
 
 ```julia
@@ -124,10 +124,10 @@ G = A - V * ∂A/∂V
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `VT_gibbs_free_energy(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     A = eos(model,V,T,z)
     return A + V*p
     #return A - V*∂A∂V
@@ -135,10 +135,10 @@ function gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,thr
 end
 
 """
-    helmholtz_free_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    helmholtz_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
-     
+
 Calculates the helmholtz free energy, defined as:
 
 ```julia
@@ -146,15 +146,15 @@ A = eos(model,V(p),T,z)
 ```
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the property via `eos(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function helmholtz_free_energy(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function helmholtz_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_helmholtz_free_energy(model,V,T,z)
 end
 
 """
-    isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J/K]`
 
@@ -166,18 +166,18 @@ Cv = -T * ∂²A/∂T²
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isochoric_heat_capacity(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 
 !!! warning "Accurate ideal model required"
     This property requires at least second order ideal model temperature derivatives. If you are computing these properties, consider using a different ideal model than the `BasicIdeal` default (e.g. `EoS(["species"];idealmodel=ReidIdeal)`).
 """
-function isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_isochoric_heat_capacity(model,V,T,z)
 end
 
 """
-    isobaric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    isobaric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J/K]`
 
@@ -189,18 +189,18 @@ Cp =  -T*(∂²A/∂T² - (∂²A/∂V∂T)^2 / ∂²A/∂V²)
 Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isobaric_heat_capacity(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 
 !!! warning "Accurate ideal model required"
     This property requires at least second order ideal model temperature derivatives. If you are computing these properties, consider using a different ideal model than the `BasicIdeal` default (e.g. `EoS(["species"];idealmodel=ReidIdeal)`).
 
 """
-function isobaric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function isobaric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_isobaric_heat_capacity(model,V,T,z)
 end
 """
-    isothermal_compressibility(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    isothermal_compressibility(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 default units: `[Pa^-1]`
 
@@ -209,42 +209,42 @@ Calculates the isothermal compressibility, defined as:
 ```julia
 κT =  (V*∂p/∂V)^-1
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isothermal_compressibility(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function isothermal_compressibility(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function isothermal_compressibility(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_isothermal_compressibility(model,V,T,z)
 end
 
 """
-    isentropic_compressibility(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    isentropic_compressibility(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
-default units: `[Pa^-1]`    
+default units: `[Pa^-1]`
 
 Calculates the isentropic compressibility, defined as:
 
 ```julia
 κS =  (V*( ∂²A/∂V² - ∂²A/∂V∂T^2 / ∂²A/∂T² ))^-1
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isentropic_compressibility(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 
 !!! warning "Accurate ideal model required"
     This property requires at least second order ideal model temperature derivatives. If you are computing these properties, consider using a different ideal model than the `BasicIdeal` default (e.g. `EoS(["species"];idealmodel=ReidIdeal)`).
 
 """
-function isentropic_compressibility(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function isentropic_compressibility(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_isentropic_compressibility(model,V,T,z)
 end
 
 """
-    speed_of_sound(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    speed_of_sound(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 default units: `[m/s]`
 
@@ -255,22 +255,22 @@ c =  V * √(∂²A/∂V² - ∂²A/∂V∂T^2 / ∂²A/∂T²)/Mr)
 ```
 Where `Mr` is the molecular weight of the model at the input composition.
 
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_speed_of_sound(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 
 !!! warning "Accurate ideal model required"
     This property requires at least second order ideal model temperature derivatives. If you are computing these properties, consider using a different ideal model than the `BasicIdeal` default (e.g. `EoS(["species"];idealmodel=ReidIdeal)`).
 
 """
-function speed_of_sound(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function speed_of_sound(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_speed_of_sound(model,V,T,z)
 end
 
 """
-    isobaric_expansivity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    isobaric_expansivity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 default units: `[K^-1]`
 
@@ -279,18 +279,18 @@ Calculates the isobaric expansivity, defined as:
 ```julia
 α =  -∂²A/∂V∂T / (V*∂²A/∂V²)
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_isobaric_expansivity(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function isobaric_expansivity(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function isobaric_expansivity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_isobaric_expansivity(model,V,T,z)
 end
 
 """
-    joule_thomson_coefficient(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    joule_thomson_coefficient(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 default units: `[K/Pa]`
 
@@ -299,23 +299,23 @@ Calculates the joule thomson coefficient, defined as:
 ```julia
 μⱼₜ =  -(∂²A/∂V∂T - ∂²A/∂V² * ((T*∂²A/∂T² + V*∂²A/∂V∂T) / (T*∂²A/∂V∂T + V*∂²A/∂V²)))^-1
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_joule_thomson_coefficient(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 
 !!! warning "Accurate ideal model required"
     This property requires at least second order ideal model temperature derivatives. If you are computing these properties, consider using a different ideal model than the `BasicIdeal` default (e.g. `EoS(["species"];idealmodel=ReidIdeal)`).
 
 """
-function joule_thomson_coefficient(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function joule_thomson_coefficient(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_joule_thomson_coefficient(model,V,T,z)
 end
 
 """
-    fugacity_coefficient(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
-     
+    fugacity_coefficient(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+
 Calculates the fugacity coefficient φᵢ, defined as:
 
 ```julia
@@ -323,19 +323,19 @@ log(φᵢ) =  μresᵢ/RT - log(Z)
 ```
 Where `μresᵢ` is the vector of residual chemical potentials and `Z` is the compressibility factor.
 
-The keywords `phase` and `threaded` are passed to [`Clapeyron.volume`](@ref).
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
+calculates the property via `VT_fugacity_coefficient(model,V,T,z)`.
+
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function fugacity_coefficient(model::EoSModel,p,T,z=SA[1.]; phase = :unknown, threaded=true)
-    V = volume(model,p,T,z;phase,threaded)
-    μ_res = VT_chemical_potential_res(model,V,T,z)
-    φ = μ_res
-    R̄ = Rgas(model)
-    Z = p*V/R̄/T/sum(z)
-    return exp.(μ_res ./ R̄ ./ T) ./ Z
+function fugacity_coefficient(model::EoSModel,p,T,z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
+    return VT_fugacity_coefficient(model,V,T,z)
 end
 
-function fugacity_coefficient!(φ,model::EoSModel,p,T,z=SA[1.]; phase = :unknown, threaded=true)
-    V = volume(model,p,T,z;phase,threaded)
+
+function fugacity_coefficient!(φ,model::EoSModel,p,T,z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     φ = VT_chemical_potential_res!(φ,model,V,T,z)
     R̄ = Rgas(model)
     Z = p*V/R̄/T/sum(z)
@@ -345,38 +345,38 @@ function fugacity_coefficient!(φ,model::EoSModel,p,T,z=SA[1.]; phase = :unknown
     return φ
 end
 
-function activity_coefficient(model::EoSModel,p,T,z=SA[1.]; phase = :unknown, threaded=true)
+function activity_coefficient(model::EoSModel,p,T,z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
     pure   = split_model(model)
-    μ_mixt = chemical_potential(model,p,T,z;phase,threaded)
-    μ_pure = gibbs_free_energy.(pure,p,T;phase,threaded)
+    μ_mixt = chemical_potential(model, p, T, z; phase, threaded, vol0)
+    μ_pure = gibbs_free_energy.(pure, p, T; phase, threaded, vol0)
     R̄ = Rgas(model)
     return exp.((μ_mixt .- μ_pure) ./ R̄ ./ T) ./z
 end
 
 """
-    compressibility_factor(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    compressibility_factor(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Calculates the compressibility factor `Z`, defined as:
 
 ```julia
 Z = p*V(p)/R*T
 ```
-The keywords `phase` and `threaded` are passed to [`Clapeyron.volume`](@ref).
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function compressibility_factor(model::EoSModel, p, T, z=SA[1.]; phase = :unknown,threaded=true)
-    V = volume(model, p, T, z; phase=phase, threaded=threaded)
+function compressibility_factor(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     R̄ = Rgas(model)
     return p*V/(sum(z)*R̄*T)
 end
 
-function inversion_temperature(model::EoSModel, p, z=SA[1.0])
+function inversion_temperature(model::EoSModel, p, z=SA[1.0]; phase=:unknown, threaded=true, vol0=nothing)
     T0 = 6.75*T_scale(model,z)
-    μⱼₜ(T) = joule_thomson_coefficient(model,p,T,z)
+    μⱼₜ(T) = joule_thomson_coefficient(model, p, T, z; phase, threaded, vol0)
     return Roots.find_zero(μⱼₜ,T0)
 end
 
 """
-    molar_density(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
+    molar_density(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 default units: `[mol/m^3]`
 
@@ -385,19 +385,19 @@ Calculates the molar density, defined as:
 ```julia
 ρₙ =  ∑nᵢ/V
 ```
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_molar_density(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function molar_density(model::EoSModel,p,T,z=SA[1.0];phase = :unknown,threaded=true)
-     V = volume(model,p,T,z;phase=phase,threaded=threaded)
+function molar_density(model::EoSModel,p,T,z=SA[1.0];phase=:unknown, threaded=true, vol0=nothing)
+     V = volume(model, p, T, z; phase, threaded, vol0)
      return VT_molar_density(model,V,T,z)
 end
 
 """
-    mass_density(model::EoSModel, p, T, z=SA[1.]; phase = :unknown, threaded=true)
-    
+    mass_density(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true)
+
 default units: `[kg/m^3]`
 
 Calculates the molar density, defined as:
@@ -407,59 +407,60 @@ Calculates the molar density, defined as:
 ```
 Where `Mr` is the molecular weight of the model at the input composition.
 
-Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and 
+Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and
 calculates the property via `VT_mass_density(model,V,T,z)`.
 
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function mass_density(model::EoSModel,p,T,z=SA[1.0];phase = :unknown,threaded=true)
-    V = volume(model,p,T,z;phase=phase,threaded=threaded)
+function mass_density(model::EoSModel, p, T, z=SA[1.0]; phase=:unknown, threaded=true, vol0=nothing)
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_mass_density(model,V,T,z)
 end
 
 """
-    mixing(model::EoSModel, p, T, z=SA[1.], property; phase = :unknown,threaded=true)
+    mixing(model::EoSModel, p, T, z=SA[1.], property; phase=:unknown, threaded=true, vol0=nothing)
 
 Calculates the mixing function for a specified property as:
 
 ```julia
 f_mix = f(p,T,z) - ∑zᵢ*f_pureᵢ(p,T)
 ```
-The keywords `phase` and `threaded` are passed to the volume solver.
+The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
-function mixing(model::EoSModel,p,T,z,property::ℜ;phase = :unknown,threaded=true) where {ℜ}
+function mixing(model::EoSModel, p, T, z, property::ℜ; phase=:unknown, threaded=true, vol0=nothing) where {ℜ}
     pure = split_model(model)
     TT = typeof(p+T+first(z))
-    mix_prop  = property(model,p,T,z;phase,threaded)
+    mix_prop  = property(model, p, T, z; phase, threaded, vol0)
     for i in 1:length(z)
-        mix_prop -= z[i]*property(pure[i],p,T;phase,threaded)
+        mix_prop -= z[i]*property(pure[i], p, T; phase, threaded, vol0)
     end
     return mix_prop::TT
 end
 
-excess(model::EoSModel,p,T,z,property) = mixing(model::EoSModel,p,T,z,property)
+function excess(model::EoSModel, p, T, z, property; phase=:unknown, threaded=true, vol0=nothing)
+    mixing(model, p, T, z, property; phase, threaded, vol0)
+end
 
-function excess(model::EoSModel,p,T,z,::typeof(entropy))
+function excess(model::EoSModel, p, T, z, ::typeof(entropy); phase=:unknown, threaded=true, vol0=nothing)
     TT = typeof(p+T+first(z))
     pure = split_model(model)
-    s_mix = entropy_res(model,p,T,z)
+    s_mix = entropy_res(model, p, T, z; phase, threaded, vol0)
     for i in 1:length(z)
-        s_mix -= z[i]*entropy_res(pure[i],p,T)
+        s_mix -= z[i]*entropy_res(pure[i], p, T; phase, threaded, vol0)
     end
     #s_pure = entropy_res.(pure,p,T)
     return s_mix::TT
 end
 
-function excess(model::EoSModel,p,T,z,::typeof(gibbs_free_energy))
+function excess(model::EoSModel, p, T, z, ::typeof(gibbs_free_energy); phase=:unknown, threaded=true, vol0=nothing)
     TT = typeof(p+T+first(z))
     pure = split_model(model)
-    g_mix = gibbs_free_energy(model,p,T,z)
+    g_mix = gibbs_free_energy(model, p, T, z; phase, threaded, vol0)
     log∑z = log(sum(z))
-    v = volume(model,p,T,z)
     R̄ = Rgas(model)
     for i in 1:length(z)
         lnxi = R̄*T*(log(z[i]) - log∑z)
-        g_mix -= z[i]*(gibbs_free_energy(pure[i],p,T) + lnxi)
+        g_mix -= z[i]*(gibbs_free_energy(pure[i], p, T; phase, threaded, vol0) + lnxi)
     end
 
     return g_mix::TT
@@ -467,7 +468,7 @@ end
 
 
 """
-    gibbs_solvation(model::EoSModel, T)
+    gibbs_solvation(model::EoSModel, T; threaded=true, vol0=(nothing,nothing))
 
 Calculates the solvation free energy as:
 
@@ -476,30 +477,30 @@ g_solv = -R̄*T*log(K)
 ```
 where the first component is the solvent and second is the solute.
 """
-function gibbs_solvation(model::EoSModel,T)
-    binary_component_check(gibbs_solvation,model)
+function gibbs_solvation(model::EoSModel, T; threaded=true, vol0=(nothing,nothing))
+    binary_component_check(gibbs_solvation, model)
     pure = split_model(model)
     z = [1.0,1e-30]
-    
+
     p,v_l,v_v = saturation_pressure(pure[1],T)
-    
-    φ_l = fugacity_coefficient(model,p,T,z;phase=:l)
-    φ_v = fugacity_coefficient(model,p,T,z;phase=:v)
-    
+
+    φ_l = fugacity_coefficient(model, p, T, z; phase=:l, threaded, vol0=vol0[1])
+    φ_v = fugacity_coefficient(model, p, T, z; phase=:v, threaded, vol0=vol0[2])
+
     K = φ_v[2]*v_v/φ_l[2]/v_l
     R̄ = Rgas(model)
     return -R̄*T*log(K)
-end    
+end
 
-function partial_property(model::EoSModel,p,T,z,property::ℜ;phase = :unknown,threaded=true) where {ℜ}
-    V = volume(model,p,T,z;phase,threaded)
+function partial_property(model::EoSModel, p, T, z, property::ℜ; phase=:unknown, threaded=true, vol0=nothing) where {ℜ}
+    V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_partial_property(model,V,T,z,property)
 end
 
 #special dispatch for volume here
-function VT_partial_property(model::EoSModel,V,T,z,property::typeof(volume))
+function VT_partial_property(model::EoSModel, V, T, z, ::typeof(volume))
     _,dpdv = p∂p∂V(model,V,T,z)
-    dpdni = VT_partial_property(model,V,T,z,pressure)
+    dpdni = VT_partial_property(model, V, T, z, pressure)
     return -dpdni ./ dpdv
 end
 

--- a/src/methods/property_solvers/multicomponent/tp_flash/DifferentialEvolutiontp_flash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/DifferentialEvolutiontp_flash.jl
@@ -4,7 +4,7 @@ Original code by Thomas Moore
 included in https://github.com/ClapeyronThermo/Clapeyron.jl/pull/56
 =#
 """
-    DETPFlash(;numphases = 2;
+    DETPFlash(; numphases = 2,
     max_steps = 1e4*(numphases-1),
     population_size =20,
     time_limit = Inf,

--- a/src/models/CompositeModel/FluidCorrelation.jl
+++ b/src/models/CompositeModel/FluidCorrelation.jl
@@ -13,13 +13,13 @@ end
 __gas_model(model::FluidCorrelation) = model.gas
 activity_coefficient(model::FluidCorrelation, p, T,z=SA[1.]; phase = :unknown, threaded=true) = FillArrays.Ones(length(model)) 
 
-function volume_impl(model::FluidCorrelation,p,T,z,phase=:unknown,threaded=false,vol0 = nothing)
+function volume_impl(model::FluidCorrelation, p, T, z, phase=:unknown, threaded=false, vol0=nothing)
     _0 = zero(p+T+first(z))
     nan = _0/_0
     if is_liquid(phase)
-        return volume(model.liquid,p,T,z;phase,threaded)
+        return volume(model.liquid, p, T, z; phase, threaded, vol0)
     elseif is_vapour(phase)
-        return volume(model.gas,p,T,z;phase,threaded)
+        return volume(model.gas, p, T, z; phase, threaded, vol0)
     else
         if length(model) == 1
             psat,vl,vv = saturation_pressure(model,T)
@@ -33,9 +33,9 @@ function volume_impl(model::FluidCorrelation,p,T,z,phase=:unknown,threaded=false
                 tc,pc,vc = crit_pure(model)
                 if T > tc #supercritical conditions. ideally, we could go along the critical isochore, but we dont have that.
                     if p > pc # supercritical fluid
-                        return volume(model.liquid,p,T,z;phase,threaded)
+                        return volume(model.liquid, p, T, z; phase, threaded, vol0)
                     else #gas phase
-                        return volume(model.gas,p,T,z;phase,threaded)
+                        return volume(model.gas, p, T, z; phase, threaded, vol0)
                     end
                 else #something failed on saturation_pressure, not related to passing the critical point
                     @error "an error ocurred while determining saturation line division."

--- a/test/test_methods_api.jl
+++ b/test/test_methods_api.jl
@@ -47,6 +47,10 @@
     @test chemical_potential(BasicIdeal(), 1e6u"Pa", 300u"K") == chemical_potential(BasicIdeal(), 1e6, 300)*u"J/mol"
     #@test Clapeyron.x0_psat(model11, 100u"K") == Clapeyron.x0_psat(model11, 100)*u"Pa"
     #@test Clapeyron.x0_sat_pure(model11, 100u"K") == Clapeyron.x0_sat_pure(model11, 100).*(u"m^3",)
+
+    # support for vol0
+    modelgergCO2 = GERG2008(["carbon dioxide"])
+    @test !isnan(only(Clapeyron.fugacity_coefficient(modelgergCO2, 1u"MPa", 300u"K"; phase=:stable, vol0=0.0023u"m^3")))
 end
 
 @testset "association" begin


### PR DESCRIPTION
This PR documents the `vol0` keyword argument of `volume`. It also adds that same keyword argument to all bulk properties that implicitly call `volume` in order to pass it along, similar to `threaded` and `phase`.

I also added a test that fails when the `vol0` keyword is not given, to illustrate a typical use-case.