### PR TITLE
Bulk properties with `CompositeModel`

### DIFF
--- a/ext/ClapeyronSymbolicsExt.jl
+++ b/ext/ClapeyronSymbolicsExt.jl
@@ -139,21 +139,15 @@ const RealZ = Union{AbstractVector{<:Real},Real}
 
 for f in (:eos,:VT_enthalpy,:VT_entropy,:VT_gibbs_free_energy,:VT_helmholtz_free_energy)
     @eval begin
-        SymbolicUtils.promote_symtype(::typeof(Clapeyron.$f), args...) = Real
-        @register_symbolic Clapeyron.$f(model::EoSModel,p,T,z::AbstractVector) false
-        @register_symbolic Clapeyron.$f(model::EoSModel,p,T,z::Symbolics.Arr{Num,1}) false
-        @register_symbolic Clapeyron.$f(model::Clapeyron.IdealModel,p,T,z::AbstractVector) false
-        @register_symbolic Clapeyron.$f(model::Clapeyron.IdealModel,p,T,z::Symbolics.Arr{Num,1}) false
+        @register_symbolic Clapeyron.$f(model::EoSModel,V,T,z::AbstractVector{<:Number})
+        @register_symbolic Clapeyron.$f(model::EoSModel,V,T,z::Symbolics.Arr{Num,1}) false
     end
 end
 
-SymbolicUtils.promote_symtype(::typeof(Clapeyron._volume), args...) = Real
-
-#SymbolicUtils.promote_symtype(::typeof(Clapeyron.dfdv), args...) = Real
-
+#SymbolicUtils.promote_symtype(::typeof(Clapeyron._volume), args...) = Real
 
 @register_symbolic Clapeyron._volume(model::EoSModel,p,T,arr::AbstractVector,
-                                     sym::Union{String,Symbol},bool::Bool,x::Union{Real,Nothing}) false
+                                     sym::Union{String,Symbol},bool::Bool,x::Union{Real,Nothing})
 @register_symbolic Clapeyron._volume(model::EoSModel,p,T,arr::Symbolics.Arr{Num,1},
                                      sym::Union{String,Symbol},bool::Bool,x::Union{Real,Nothing}) false
 

--- a/src/base/EoSModel.jl
+++ b/src/base/EoSModel.jl
@@ -1,6 +1,6 @@
 abstract type EoSModel end
 
-function eos_impl(model,V,T,z)
+function eos_impl(model::EoSModel,V,T,z)
     return Rgas(model)*sum(z)*T*a_eos(model,V,T,z) + reference_state_eval(model,V,T,z)
 end
 

--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -1,4 +1,5 @@
 const N_A = 6.02214076e23 # mol-1
+const ln_N_A = 54.75489994294367 #log(N_A)
 const k_B = 1.380649e-23 # m2 kg s-2 K-1
 const R̄   = N_A*k_B # m2 kg s-2 K-1 mol-1
 const ħ = 1.054571817e-34 # J s

--- a/src/methods/pT.jl
+++ b/src/methods/pT.jl
@@ -1,3 +1,16 @@
+function PT_property(model,p,T,z,phase,threaded,vol0,f::F,::Val{UseP}) where {F,UseP}
+    V = volume(model, p, T, z; phase, threaded, vol0)
+    if UseP
+        return f(model,V,T,z,p)
+    else
+        return f(model,V,T,z)
+    end
+end
+
+function PT_property(model,p,T,z,phase,threaded,vol0,f::F) where F
+    PT_property(model,p,T,z,phase,threaded,vol0,f,Val{false}())
+end
+
 """
     entropy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
@@ -13,8 +26,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function entropy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_entropy(model, V, T, z)
+    return PT_property(model,p,T,z,phase,threaded,vol0,VT_entropy)
 end
 
 """
@@ -32,8 +44,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function entropy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_entropy_res(model, V, T, z)
+    return PT_property(model,p,T,z,phase,threaded,vol0,VT_entropy_res)
 end
 
 """
@@ -51,8 +62,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function chemical_potential(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_chemical_potential(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_chemical_potential)
 end
 
 """
@@ -70,8 +80,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function chemical_potential_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_chemical_potential_res(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_chemical_potential_res)
 end
 
 """
@@ -89,8 +98,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function internal_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_internal_energy(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_internal_energy)
 end
 
 """
@@ -108,8 +116,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function internal_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_internal_energy_res(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_internal_energy_res_res)
 end
 
 """
@@ -127,8 +134,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function enthalpy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_enthalpy(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_enthalpy)
 end
 
 """
@@ -146,12 +152,12 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function enthalpy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_enthalpy_res(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_enthalpy_res)
 end
 
 """
     gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    gibbs_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
 
@@ -165,15 +171,12 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function gibbs_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    A = eos(model,V,T,z)
-    return A + V*p
-    #return A - V*∂A∂V
-    #return VT_gibbs_free_energy(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_gibbs_free_energy,Val{true}())
 end
 
 """
     gibbs_free_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    gibbs_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
 
@@ -187,12 +190,12 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function gibbs_free_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_gibbs_free_energy_res(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_gibbs_free_energy_res)
 end
 
 """
     helmholtz_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    helmholtz_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
 
@@ -206,12 +209,12 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function helmholtz_free_energy(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_helmholtz_free_energy(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_helmholtz_free_energy)
 end
 
 """
     helmholtz_free_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    helmholtz_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
 
 Default units: `[J]`
 
@@ -225,9 +228,13 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function helmholtz_free_energy_res(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_helmholtz_free_energy_res(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_helmholtz_free_energy_res)
 end
+
+const helmholtz_energy = helmholtz_free_energy
+const helmholtz_energy_res = helmholtz_free_energy_res 
+const gibbs_energy = gibbs_free_energy
+const gibbs_energy_res = gibbs_free_energy_res
 
 """
     isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
@@ -248,8 +255,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
     This property requires at least second order ideal model temperature derivatives. If you are computing these properties, consider using a different ideal model than the `BasicIdeal` default (e.g. `EoS(["species"];idealmodel = ReidIdeal)`).
 """
 function isochoric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_isochoric_heat_capacity(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_isochoric_heat_capacity)
 end
 
 """
@@ -272,8 +278,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
 
 """
 function isobaric_heat_capacity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_isobaric_heat_capacity(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_isobaric_heat_capacity)
 end
 
 """
@@ -296,8 +301,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
 
 """
 function adiabatic_index(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_adiabatic_index(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_adiabatic_index)
 end
 
 """
@@ -316,8 +320,7 @@ calculates the property via `VT_isothermal_compressibility(model,V,T,z)`.
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function isothermal_compressibility(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_isothermal_compressibility(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_isothermal_compressibility)
 end
 
 """
@@ -340,8 +343,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
 
 """
 function isentropic_compressibility(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_isentropic_compressibility(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_isentropic_compressibility)
 end
 
 """
@@ -366,8 +368,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
 
 """
 function speed_of_sound(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_speed_of_sound(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_speed_of_sound)
 end
 
 """
@@ -386,8 +387,7 @@ calculates the property via `VT_isobaric_expansivity(model,V,T,z)`.
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function isobaric_expansivity(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_isobaric_expansivity(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_isobaric_expansivity)
 end
 
 """
@@ -410,8 +410,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
 
 """
 function joule_thomson_coefficient(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_joule_thomson_coefficient(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_joule_thomson_coefficient)
 end
 
 """
@@ -428,6 +427,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function identify_phase(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
+    #TODO: what do we do with composite models here?
     V = volume(model, p, T, z; phase, threaded, vol0)
     return VT_identify_phase(model,V,T,z)
 end
@@ -442,8 +442,7 @@ Internally, it calls [`Clapeyron.volume`](@ref) to obtain `V` and calculates the
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function fundamental_derivative_of_gas_dynamics(model::EoSModel, p, T, z=SA[1.]; phase=:gas, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_fundamental_derivative_of_gas_dynamics(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_fundamental_derivative_of_gas_dynamics)
 end
 
 """
@@ -462,8 +461,7 @@ calculates the property via `VT_fugacity_coefficient(model,V,T,z)`.
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function fugacity_coefficient(model::EoSModel,p,T,z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    return VT_fugacity_coefficient(model,V,T,z)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_fugacity_coefficient)
 end
 
 
@@ -643,9 +641,7 @@ Z = p*V(p)/R*T
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 """
 function compressibility_factor(model::EoSModel, p, T, z=SA[1.]; phase=:unknown, threaded=true, vol0=nothing)
-    V = volume(model, p, T, z; phase, threaded, vol0)
-    R̄ = Rgas(model)
-    return p*V/(sum(z)*R̄*T)
+    PT_property(model,p,T,z,phase,threaded,vol0,VT_compressibility_factor,Val{true}())
 end
 
 function inversion_temperature(model::EoSModel, p, z=SA[1.0]; phase=:unknown, threaded=true, vol0=nothing)
@@ -786,6 +782,8 @@ end
 #first derivative order properties
 export entropy, internal_energy, enthalpy, gibbs_free_energy, helmholtz_free_energy
 export entropy_res, internal_energy_res, enthalpy_res, gibbs_free_energy_res, helmholtz_free_energy_res
+export gibbs_energy,helmholtz_energy,gibbs_energy_res,helmholtz_energy_res
+
 #second derivative order properties
 export isochoric_heat_capacity, isobaric_heat_capacity,adiabatic_index
 export isothermal_compressibility, isentropic_compressibility, speed_of_sound

--- a/src/methods/property_solvers/volume.jl
+++ b/src/methods/property_solvers/volume.jl
@@ -181,8 +181,13 @@ function _volume(model::EoSModel,p,T,z=SA[1.0],phase=:unknown, threaded=true,vol
     return volume_impl(model,p,T,z,phase,threaded,vol0)
 end
 
+#comprises solid and liquid phases.
+#the separation is done because we normally we use a combined liquid-gas model for most calculations.
 fluid_model(model) = model
+#just solid models.
 solid_model(model) = model
+liquid_model(model) = fluid_model(model)
+gas_model(model) = fluid_model(model)
 
 volume_impl(model,p,T) = volume_impl(model,p,T,SA[1.0],:unknown,true,nothing)
 volume_impl(model,p,T,z) = volume_impl(model,p,T,z,:unknown,true,nothing)

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -98,8 +98,8 @@ If the model is not an `IdealModel`, then `Clapeyron.idealmodel(model)` will be 
 
 function ideal_consistency(model,V,T,z =SA[1.0])
     id = idealmodel(model)
-    if id === nothing
-        f(∂V) = a_ideal(model,∂V,T,z) || id === model
+    if id === nothing || id === model
+        f(∂V) = a_ideal(model,∂V,T,z)
         ∂f0∂V = Solvers.derivative(f,V)
         n = sum(z)
         return abs(∂f0∂V + 1/V)

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -99,7 +99,7 @@ If the model is not an `IdealModel`, then `Clapeyron.idealmodel(model)` will be 
 function ideal_consistency(model,V,T,z =SA[1.0])
     id = idealmodel(model)
     if id === nothing
-        f(∂V) = a_ideal(model,∂V,T,z)
+        f(∂V) = a_ideal(model,∂V,T,z) || id === model
         ∂f0∂V = Solvers.derivative(f,V)
         n = sum(z)
         return abs(∂f0∂V + 1/V)

--- a/src/models/CompositeModel/FluidCorrelation.jl
+++ b/src/models/CompositeModel/FluidCorrelation.jl
@@ -1,16 +1,114 @@
 """
-    FluidCorrelation{V,L,Sat} <: RestrictedEquilibriaModel
+    FluidCorrelation{V,L,Sat,Cp} <: RestrictedEquilibriaModel
 
 Wrapper struct to signal that a `CompositeModel` uses correlations for calculation of saturation points, vapour and liquid phase volumes.
 """
-struct FluidCorrelation{V,L,Sat} <: RestrictedEquilibriaModel
+struct FluidCorrelation{V,L,Sat,Cp} <: RestrictedEquilibriaModel
     components::Vector{String}
     gas::V
     liquid::L
     saturation::Sat
+    liquid_cp::Cp
+end
+
+function FluidCorrelation(_components;
+                            gas_volume = nothing,
+                            liquid_volume = nothing,
+                            saturation = nothing,
+                            liquid_cp = nothing
+                            ,gas_volume_userlocations = String[],
+                            liquid_volume_userlocations = String[],
+                            saturation_userlocations = String[],
+                            liquid_cp_userlocations = String[],
+                            verbose = false,
+                            liquid_reference_state = :ntp) #=Coolprop uses this reference=#
+
+    components = format_components(_components)
+    if gas_volume != nothing
+        init_gas = init_model(gas_volume,components,gas_volume_userlocations,verbose)
+    else
+        init_gas = nothing
+    end
+
+    if liquid_volume != nothing
+        init_liquid = init_model(liquid_volume,components,liquid_volume_userlocations,verbose)
+    else
+        init_liquid = nothing
+    end
+
+    if saturation != nothing
+        init_sat = init_model(saturation,components,saturation_userlocations,verbose)
+    else
+        init_sat = nothing
+    end
+
+    if liquid_cp != nothing
+        init_cp = init_model(liquid_cp,components,liquid_cp_userlocations,verbose)
+    else
+        init_cp = nothing
+    end
+
+
+    model = FluidCorrelation(components,init_gas,init_liquid,init_sat,init_cp)
+    return model
+end
+
+function Base.show(io::IO,mime::MIME"text/plain",model::FluidCorrelation)
+    print(io,"Fluid Correlation Model")
+    length(model) == 1 && print(io, " with 1 component:")
+    length(model) > 1 && print(io, " with ", length(model), " components:")
+    model.gas !== nothing && print(io,'\n'," Gas Model: ",model.gas)
+    model.liquid !== nothing && print(io,'\n'," Liquid Model: ",model.liquid)
+    model.saturation !== nothing && print(io,'\n'," Saturation Model: ",model.saturation)
+    model.liquid_cp !== nothing && print(io,'\n'," Liquid Caloric Model: ",model.liquid_cp)
+end
+
+reference_state(model::FluidCorrelation) = reference_state(model.gas)
+
+function idealmodel(model::FluidCorrelation{V}) where V
+    idealmodel(model.gas)
 end
 
 gas_model(model::FluidCorrelation) = model.gas
+
+function PT_property(model::FluidCorrelation,p,T,z,phase,threaded,vol0,f::F,USEP::Val{UseP}) where {F,UseP}
+    if is_unknown(phase) || phase == :stable
+        #only liquid phase available
+        if model.liquid_cp === nothing && model.gas !== nothing
+            return PT_property(gas_model(model),p,T,z,phase,threaded,vol0,f,USEP)
+        end
+
+        #only gas phase available
+        if model.gas === nothing && model.liquid_cp !== nothing
+            return PT_property(model.liquid_cp,p,T,z,phase,threaded,vol0,f,USEP)
+        end
+
+        #single component, both phase models available, use saturation pressure to select
+        if model.gas !== nothing && model.liquid_cp !== nothing && length(model) == 1
+            psat,_,_ = saturation_pressure(model.saturation,T)
+            if isnan(psat)
+                #fluid correlations are only available on subcritical regime, where
+                #we can distinguish a liquid from a vapour.
+                nan = zero(Base.promote_eltype(model,p,T,z))
+                return PT_property(model.gas,nan,nan,z,phase,threaded,vol0,f,USEP)
+            end
+
+            #phase identified, call again with correct phase
+            new_phase = p > psat ? :l : :v
+            return PT_property(model,p,T,z,new_phase,threaded,vol0,f,USEP)
+        end
+        throw(error("multicomponent automatic phase detection not implemented for $(typeof(model))"))
+    end
+
+    if is_liquid(phase)
+        #for bulk properties that arent volume, the liquid_cp model contains a valid helmholtz model
+        return PT_property(model.liquid_cp,p,T,z,phase,threaded,vol0,f,USEP)
+    elseif is_vapour(phase)
+        return PT_property(model.gas,p,T,z,phase,threaded,vol0,f,USEP)
+    else
+        throw(error("invalid phase specifier for FluidCorrelation: $phase"))
+    end
+end
 
 function activity_coefficient(model::FluidCorrelation,p,T,z=SA[1.];
     μ_ref = nothing,
@@ -21,10 +119,36 @@ function activity_coefficient(model::FluidCorrelation,p,T,z=SA[1.];
     return FillArrays.Ones(length(model))
 end
 
+function a_res_activity(model,V,T,z,pures::EoSVectorParam{M}) where M <: FluidCorrelation{E} where E
+    if pures.model.gas isa IdealModel
+        return a_res_activity(model,V,T,z,BasicIdeal())
+    end
+    Σz = sum(z)
+    R = Rgas(model)
+    v = V/Σz
+    Σa_resᵢ = sum(z[i]*a_res(pures[i].gas,v,T,SA[1.0]) for i ∈ @comps)
+    nRT = Σz*R*T
+    if model isa ActivityModel
+        p = nRT/V
+    else
+        p = pressure(pures.model.gas,V,T,z)
+    end
+    g_E = excess_gibbs_free_energy(model,p,T,z)
+    return g_E/(Σz*Rgas(model)*T) + Σa_resᵢ
+end
+
+
 reference_chemical_potential_type(model::FluidCorrelation) = :zero
 
 function volume_impl(model::FluidCorrelation, p, T, z, phase, threaded, vol0)
     _0 = zero(p+T+first(z))
+    _1 = one(_0)
+    if model.gas === nothing && model.liquid !== nothing
+        return _1*volume_impl(model.liquid,p,T,z,phase,threaded,vol0)
+    elseif model.liquid === nothing && model.gas !== nothing
+        return _1*volume_impl(model.gas,p,T,z,phase,threaded,vol0)
+    end
+    
     nan = _0/_0
     if is_liquid(phase)
         return volume(model.liquid, p, T, z; phase, threaded, vol0)
@@ -48,7 +172,6 @@ function volume_impl(model::FluidCorrelation, p, T, z, phase, threaded, vol0)
                         return volume(model.gas, p, T, z; phase, threaded, vol0)
                     end
                 else #something failed on saturation_pressure, not related to passing the critical point
-                    @error "an error ocurred while determining saturation line division."
                     return nan
                 end
 
@@ -56,7 +179,7 @@ function volume_impl(model::FluidCorrelation, p, T, z, phase, threaded, vol0)
 
             return nan
         else
-            @error "A phase needs to be specified on multicomponent composite models."
+            throw(error("multicomponent automatic phase detection not implemented for $(typeof(model))"))
             return nan
         end
     end

--- a/src/models/EmpiricHelmholtz/SingleFluid/SingleFluid.jl
+++ b/src/models/EmpiricHelmholtz/SingleFluid/SingleFluid.jl
@@ -1,7 +1,7 @@
 
 include("structs.jl")
 
-const EmpiricAncillary = CompositeModel{FluidCorrelation{PolExpVapour, PolExpLiquid, PolExpSat}, Nothing}
+const EmpiricAncillary = CompositeModel{FluidCorrelation{PolExpVapour, PolExpLiquid, PolExpSat, Nothing}, Nothing}
 #term dispatch. function definitions are in term_functions.jl
 
 function a_term(term::NonAnalyticTerm,δ,τ,lnδ,lnτ,_0)

--- a/src/models/ideal/ideal.jl
+++ b/src/models/ideal/ideal.jl
@@ -1,49 +1,10 @@
 
-function eos_impl(model::IdealModel, V, T, z)
-    return Rgas(model)*sum(z)*T *(a_ideal(model,V,T,z) + reference_state_eval(model,V,T,z))
-end
-
-for f in (:eos_res,:a_res,:VT_entropy_res,:VT_gibbs_free_energy_res,:VT_helmholtz_free_energy_res)
-    @eval begin
-        function $f(model::IdealModel, V, T, z=SA[1.])
-            return zero(V+T+first(z))
-        end
-    end
-end
+a_res(model::IdealModel,V,T,z) = zero(Base.promote_eltype(model,V,T,z))
 
 function volume_impl(model::IdealModel,p,T,z,phase,threaded,vol0)
     return sum(z)*R̄*T/p
 end
 
-function VT_chemical_potential_res(model::IdealModel, V, T, z)
-    return false .* z
-end
-
-function VT_entropy(model::IdealModel, V, T, z=SA[1.])
-    return -∂f∂T(model,V,T,z)
-end
-
-function VT_internal_energy(model::IdealModel, V, T, z=SA[1.])
-    V₀ = oneunit(V)
-    A, ∂A∂T = f∂fdT(model,V₀,T,z)
-    return A - T*∂A∂T
-end
-
-function VT_enthalpy(model::IdealModel, V, T, z=SA[1.])
-    #idealmodels don't have a volume dependence for enthalpy
-    V₀ = oneunit(V)
-    A, ∂A∂T = f∂fdT(model,V₀,T,z)
-    return A + sum(z)*Rgas(model)*T - T*∂A∂T
-end
-
-function VT_gibbs_free_energy(model::IdealModel, V, T, z=SA[1.])
-    return eos(model,V,T,z) + sum(z)*Rgas(model)*T
-end
-
-function VT_helmholtz_free_energy(model::IdealModel, V, T, z=SA[1.])
-    return eos(model,V,T,z)
-end
-
 lb_volume(model::IdealModel,z) = zero(eltype(z))
 
-idealmodel(model::IdealModel) = nothing
+idealmodel(model::IdealModel) = model

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -157,7 +157,7 @@ viewlast(x,i) = @view(x[(end - i + 1):end])
 viewfirst(x,i) = @view(x[begin:i])
 
 
-linearidx(x::AbstractVector) = 1:length(x)
-linearidx(x::AbstractMatrix) = diagind(x)
+linearidx(x::AbstractVector) = LinearIndices(x)
+linearidx(x::AbstractMatrix) = diagind(A, 0, IndexStyle(A))
 
 mid(a,b,c) =  max(min(a,b),min(max(a,b),c))

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -158,6 +158,6 @@ viewfirst(x,i) = @view(x[begin:i])
 
 
 linearidx(x::AbstractVector) = LinearIndices(x)
-linearidx(x::AbstractMatrix) = diagind(A, 0, IndexStyle(A))
+linearidx(x::AbstractMatrix) = diagind(x, 0, IndexStyle(x))
 
 mid(a,b,c) =  max(min(a,b),min(max(a,b),c))

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -158,6 +158,11 @@ viewfirst(x,i) = @view(x[begin:i])
 
 
 linearidx(x::AbstractVector) = LinearIndices(x)
-linearidx(x::AbstractMatrix) = diagind(x, 0, IndexStyle(x))
+
+if Base.VERSION < v"1.11"
+    linearidx(x::AbstractMatrix) = diagind(x,0)
+else
+    linearidx(x::AbstractMatrix) = diagind(x,0,IndexStyle(x))
+end
 
 mid(a,b,c) =  max(min(a,b),min(max(a,b),c))


### PR DESCRIPTION
This PR adds the groundwork necessary to start calculating bulk caloric properties with `CompositeModel`. it is missing an automatic phase detection algo (calculating the equilibria). On gamma-phi models, it calculates the caloric properties taking the activity model in account.
This PR also adds a constructor for `FluidCorrelation`. It is recommended to use this constructor instead of the `CompositeModel` one, but at the moment, they have the same functionality.
The final idea of this is to allow calculating caloric properties from incompressible fluids,including support for setting reference states.

The proposed api for an incomp fluid is:
```
FluidCorrelation(components, liquid = RackettLiquid, liquid_cp = PolynomialCpLiquid)
```
The API is active, but there aren't at the moment any models.