### PR TITLE
`@generated` split model

### DIFF
--- a/src/methods/pT.jl
+++ b/src/methods/pT.jl
@@ -609,7 +609,7 @@ The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume
 """
 function reference_chemical_potential(model::EoSModel,p,T,reference = reference_chemical_potential_type(model); phase=:unknown, threaded=true, vol0=nothing)
     if reference == :pure
-        pure = split_model.(model)
+        pure = split_model(model)
         return gibbs_free_energy.(pure, p, T; phase, threaded)
     elseif reference == :aqueous
         idx_w = find_water_indx(model)
@@ -621,7 +621,7 @@ function reference_chemical_potential(model::EoSModel,p,T,reference = reference_
         zref ./= sum(zref)
         return chemical_potential(model, p, T, zref; phase, threaded, vol0)
     elseif reference == :sat_pure_T
-        pure = split_model.(model)
+        pure = split_model(model)
         sat = saturation_pressure.(pure,T)
         vl_pure = getindex.(sat,2)
         return VT_gibbs_free_energy.(pure, vl_pure, T)

--- a/src/models/ECS/ECS.jl
+++ b/src/models/ECS/ECS.jl
@@ -202,10 +202,10 @@ function x0_sat_pure(model::ECS,T,crit = nothing)
     return (v0l*h,v0v*h)
 end
 
-function split_model(model::ECS,splitter)
-    shape_model_vec = split_model(model.shape_model,splitter)
+function each_split_model(model::ECS,I)
+    shape_model = each_split_model(model.shape_model,I)
     shape_ref,model_ref = model.shape_ref, model.model_ref
-    return [ECS(shape_modeli,shape_ref,model_ref) for shape_modeli in shape_model_vec]
+    ECS(shape_model,shape_ref,model_ref)
 end
 
 #==

--- a/src/utils/index_reduction.jl
+++ b/src/utils/index_reduction.jl
@@ -11,9 +11,7 @@ if the model does not have empty compositions, it will just return the input mod
 
 The function will error if the reduction results in an empty model.
 
-you can pass an arbitrary boolean vector (`bools`) to perform the reduction.
-```
-
+You can pass an arbitrary boolean vector (`bools`) to perform the reduction.
 """
 function index_reduction(model::EoSModel,z::AbstractVector,zmin = sum(z)*4*eps(float(oneunit(eltype(z)))))
     #skip splitting if possible

--- a/src/utils/index_reduction.jl
+++ b/src/utils/index_reduction.jl
@@ -38,7 +38,7 @@ function index_reduction(model::EoSModel,bools::T) where T<:AbstractVector{Bool}
     elseif all(idx)
         model_r = model
     else
-        model_r = split_model(model,[findall(idx)]) |> only
+        model_r = each_split_model(model,findall(idx))
     end
     return model_r,idx
 end

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -362,6 +362,16 @@ function split_model(param::AbstractArray,splitter)
 end
 
 #inner method to dispatch on type of splitter
+
+#general splitter type is an iterator with eltype <: AbstractVector{Int}
+function _split_model(param,splitter)
+    if is_splittable(param) || param isa EoSModel
+        return map(Base.Fix1(each_split_model,param),splitter)
+    else
+        return [fill(param,length(i)) for i ∈ splitter]
+    end
+end
+
 function _split_model(param,splitter::AbstractVector{Int})
     if is_splittable(param) || param isa EoSModel
         f(i) = each_split_model(param,i:i)
@@ -371,17 +381,11 @@ function _split_model(param,splitter::AbstractVector{Int})
     end
 end
 
-_split_model(param,i::Int) = [each_split_model(param,i:i)]
 
-function _split_model(param,splitter::AbstractVector)
-    if is_splittable(param)
-        return map(Base.Fix1(each_split_model,param),splitter)
-    else
-        return [fill(param,length(i)) for i ∈ splitter]
-    end
-end
+
 
 _split_model(param,splitter::Nothing) = split_model(param)
+_split_model(param,i::Int) = [each_split_model(param,i:i)]
 
 for T in (:Symbol,:Tuple,:AbstractString,:Number,:Missing,:Nothing)
     @eval is_splittable(param::$T) = false

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -109,7 +109,9 @@ end
 
 function each_split_model(param::Union{SingleParameter,PairParameter,AssocParam},group,I_component,I_group)
     components = param.components
-    if components == group.components
+    if group === nothing
+        return each_split_model(param,I_component)
+    elseif components == group.components
         return each_split_model(param,I_component)
     elseif components == group.flattenedgroups
         return each_split_model(param,I_group)
@@ -236,22 +238,7 @@ function each_split_model(group::GroupParam,I)
 end
 
 function each_split_model(param::SiteParam,I)
-    return each_split_model(param,nothing,I,nothing)
-end
-
-function each_split_model(param::SiteParam,group,Ic,Ig)
-    
-    if group === nothing
-        I = Ic
-    elseif param.components == group.components
-        I = Ic
-    elseif param.components == group.flattenedgroups
-        I = Ig
-    else
-        __each_split_model_ambiguous_comps("sites",SiteParam)
-    end
-
-    site = SiteParam(
+    return SiteParam(
         param.components[I],
         param.sites[I],
         each_split_model(param.n_sites,I),
@@ -261,11 +248,26 @@ function each_split_model(param::SiteParam,group,Ic,Ig)
         param.i_flattenedsites[I],
         param.sourcecsvs,
         __split_site_translator(param.site_translator,I))
+end
+
+function each_split_model(param::SiteParam,group,Ic,Ig)
     
+    components = param.components
+    if group === nothing
+        site = each_split_model(param,Ic)
+    elseif components == group.components
+        site = each_split_model(param,Ic)
+    elseif components == group.flattenedgroups
+        site = each_split_model(param,Ig)
+    else
+        __each_split_model_ambiguous_comps("sites",SiteParam)
+    end
+
     if group != nothing && site.site_translator != nothing && I == Ic
         ng = length(group.flattenedgroups)
         recalculate_site_translator!(site,Ig,ng)
     end
+    
     return site
 end
 

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -239,7 +239,18 @@ function each_split_model(param::SiteParam,I)
     return each_split_model(param,nothing,I,nothing)
 end
 
-function each_split_model(param::SiteParam,group,I,Ig)
+function each_split_model(param::SiteParam,group,Ic,Ig)
+    
+    if group === nothing
+        I = Ic
+    elseif param.components == group.components
+        I = Ic
+    elseif param.components == group.flattenedgroups
+        I = Ig
+    else
+        __each_split_model_ambiguous_comps("sites",SiteParam)
+    end
+
     site = SiteParam(
         param.components[I],
         param.sites[I],
@@ -251,7 +262,7 @@ function each_split_model(param::SiteParam,group,I,Ig)
         param.sourcecsvs,
         __split_site_translator(param.site_translator,I))
     
-    if group != nothing && site.site_translator != nothing
+    if group != nothing && site.site_translator != nothing && I == Ic
         ng = length(group.flattenedgroups)
         recalculate_site_translator!(site,Ig,ng)
     end
@@ -369,8 +380,6 @@ function _split_model(param,splitter::AbstractVector)
 end
 
 _split_model(param,splitter::Nothing) = split_model(param)
-
-
 
 for T in (:Symbol,:Tuple,:AbstractString,:Number,:Missing,:Nothing)
     @eval is_splittable(param::$T) = false

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -1,3 +1,38 @@
+#generated each_split_model for structs
+function _each_split_model(param,field,fieldname,group,Ic,Ig)
+    if !is_splittable(field)
+        return field
+    elseif isnothing(group)
+        return each_split_model(field,Ic)
+    else
+        return each_split_model(field,group,Ic,Ig)
+    end
+end
+
+function _each_split_model(param::EoSModel,field,fieldname,group,Ic,Ig)
+    if !is_splittable(field) || fieldname == :references
+        return field
+    elseif fieldname == :components || isnothing(group) || field isa EoSModel
+        return each_split_model(field,Ic)
+    else
+        return each_split_model(field,group,Ic,Ig)
+    end
+end
+
+@generated function each_split_model_struct(param::P,group,Ic,Ig) where {P}
+    all_fields = fieldnames(P)
+    r = Expr(:call,Base.typename(P).wrapper)
+    for field in all_fields
+            field_sym = QuoteNode(field)
+            push!(r.args,:(_each_split_model($param,param.$field,$field_sym,group,Ic,Ig)))
+    end
+    return r
+end
+
+each_split_model_struct(param,I) = each_split_model_struct(param,nothing,I,nothing)
+
+each_split_model(model,group,I_component,I_group) = each_split_model(model,I_component)
+
 function each_split_model(param::AbstractVector,I)
     val = param[I]
     eltype(param) <: AbstractArray && return deepcopy(val)
@@ -55,7 +90,7 @@ function each_split_model(assoc::Compressed4DMatrix{T},I) where T
     len = length(assoc.values)
     iszero(len) && return Compressed4DMatrix{T}()
     old_idx = assoc.outer_indices
-    idx_bool = findall(x -> (first(x) ∈ I)&(last(x) ∈ I),old_idx)
+    idx_bool = findall(x -> (first(x) ∈ I) & (last(x) ∈ I),old_idx)
     iszero(length(idx_bool)) && return Compressed4DMatrix{T}()
     values = assoc.values[idx_bool]
     outer_indices = assoc.outer_indices[idx_bool]
@@ -70,6 +105,29 @@ function each_split_model(assoc::Compressed4DMatrix{T},I) where T
         outer_indices[i] = (i2,j2)
     end
     return Compressed4DMatrix(values,outer_indices,inner_indices,outer_size,inner_size)
+end
+
+function each_split_model(param::Union{SingleParameter,PairParameter,AssocParam},group,I_component,I_group)
+    components = param.components
+    if components == group.components
+        return each_split_model(param,I_component)
+    elseif components == group.flattenedgroups
+        return each_split_model(param,I_group)
+    else
+        __each_split_model_ambiguous_comps(param.name,typeof(param))
+    end
+end
+
+@noinline function __each_split_model_ambiguous_comps(param,paramtype)
+    throw(Argument("$param ($paramtype) is in a GC model, but does not have compatible component names for either component-based or group-based splitting."))
+end
+
+function each_split_model(param::EoSParam,group,Ic,Ig)
+    each_split_model_struct(param,group,Ic,Ig)
+end
+
+function each_split_model(param::EoSParam,I)
+    each_split_model_struct(param,I)
 end
 
 function each_split_model(param::SingleParameter,I)
@@ -110,24 +168,28 @@ function each_split_model(param::AssocParam,I)
             )
 end
 
-function gc_each_split_model(param::GroupParam,I)
+function create_group_splitter(param::GroupParam,I)
+    flattenedgroups = param.flattenedgroups
+    len_groups = length(flattenedgroups)
+    Ig = zeros(Int,len_groups)
+    for i in I
+        group_i = param.groups[i]
+        for k in 1:length(group_i)
+            j = findfirst(==(group_i[k]),flattenedgroups)::Int
+            Ig[j] = j
+        end
+    end
+    filter!(!iszero,Ig)
+    return Ig
+end
+
+function each_split_model(param::GroupParam,__group,I,_idx)
     grouptype = param.grouptype
     components = param.components[I]
     groups = param.groups[I]
     n_groups = param.n_groups[I]
     sourcecsvs = param.sourcecsvs
-
-    #unique, but without allocating sets.
-    _idx = zeros(Bool,length(param.flattenedgroups))
-    for i in I
-        group_i = param.groups[i]
-        for k in 1:length(group_i)
-            j = findfirst(==(group_i[k]),param.flattenedgroups)::Int
-            _idx[j] = true
-        end
-    end
-
-    len_groups = length(_idx)
+    len_groups = length(param.flattenedgroups)
 
     flattenedgroups = param.flattenedgroups[_idx]
     i_groups = [[findfirst(isequal(group), flattenedgroups)::Int for group ∈ componentgroups] for componentgroups ∈ groups]
@@ -150,11 +212,11 @@ function gc_each_split_model(param::GroupParam,I)
 
     for (k,i) in pairs(I)
         pii = param.n_groups_cache[i]
-        true_n = (pii[_idx])
+        true_n = pii[_idx]
         n_groups_cache[k] .= true_n
     end
 
-    return _idx,GroupParam(
+    return GroupParam(
         components,
         groups,
         grouptype,
@@ -169,12 +231,16 @@ end
 
 
 function each_split_model(group::GroupParam,I)
-    _,gi = gc_each_split_model(group,I)
-    return gi
+    Ig = create_group_splitter(group,I)
+    return each_split_model(group,group,I,Ig)
 end
 
 function each_split_model(param::SiteParam,I)
-    return SiteParam(
+    return each_split_model(param,nothing,I,nothing)
+end
+
+function each_split_model(param::SiteParam,group,I,Ig)
+    site = SiteParam(
         param.components[I],
         param.sites[I],
         each_split_model(param.n_sites,I),
@@ -184,11 +250,57 @@ function each_split_model(param::SiteParam,I)
         param.i_flattenedsites[I],
         param.sourcecsvs,
         __split_site_translator(param.site_translator,I))
+    
+    if group != nothing && site.site_translator != nothing
+        ng = length(group.flattenedgroups)
+        recalculate_site_translator!(site,Ig,ng)
+    end
+    return site
 end
 
 __split_site_translator(::Nothing,I) = nothing
 __split_site_translator(s::Vector{Vector{NTuple{2,Int}}},I) = s[I]
 
+function recalculate_site_translator!(sites::SiteParam,idxi,ng,bool_to_int = Int[])
+    site_translator_i = sites.site_translator::Vector{Vector{NTuple{2,Int}}}
+    #the tuple is (ki,site_kia) where ki is the position of the group, and site_ki is the site number in GC based sites
+    #DO NOT use the second number. if you really need it, store the original SiteParam instead.
+    #the first number is used to reference the gc pair at an specific component, via get_group_idx
+
+    resize!(bool_to_int,ng)
+    bool_to_int .= 0
+    wk = 0
+    for w in 1:ng
+        if w in idxi
+            wk += 1
+            bool_to_int[w] = wk
+        end
+    end
+    for (l,s0) in pairs(site_translator_i)
+        si = copy(s0)
+        iszero(length(si)) && continue
+        for a in 1:length(si)
+            ki,_ = si[a]
+            ki_new = bool_to_int[ki] #splitted group new index, if not zero
+            si[a] = (ki_new,0)
+
+        end
+        site_translator_i[l] = filter!(x -> !iszero(first(x)),si)
+    end
+end
+
+#EoSModel each_split_model code.
+
+function each_split_model(model::EoSModel,I)
+    if has_groups(model)
+        Ic = I
+        groups = model.groups
+        Ig = create_group_splitter(groups,I)
+        return each_split_model_struct(model,groups,Ic,Ig)
+    else
+        return each_split_model_struct(model,I)
+    end
+end
 
 """
     split_model(model::EoSModel)
@@ -227,7 +339,7 @@ end
 #general method
 function split_model(param,splitter)
     if is_splittable(param)
-        return [each_split_model(param,i) for i ∈ splitter]
+        return map(Base.Fix1(each_split_model,param),splitter)
     else
         return [fill(param,length(i)) for i ∈ splitter]
     end
@@ -236,7 +348,7 @@ end
 function split_model(param::AbstractArray,splitter)
     s = size(param)
     length(s) > 1 && (@assert reduce(isequal,s))
-    return [each_split_model(param,i) for i ∈ splitter]
+    return map(Base.Fix1(each_split_model,param),splitter)
 end
 
 for T in (:Symbol,:Tuple,:AbstractString,:Number,:Missing,:Nothing)
@@ -254,186 +366,6 @@ end
 default_splitter(param::ClapeyronParam) = _n_splitter(length(param.components))
 default_splitter(param::EoSModel) = _n_splitter(length(param.components))
 default_splitter(param::AbstractArray) = _n_splitter(size(param,1))
-
-function split_model(Base.@nospecialize(params::EoSParam),splitter)
-    T = typeof(params)
-    split_paramsvals = (split_model(getfield(params,i),splitter) for i  ∈ fieldnames(T))
-    return T.(split_paramsvals...)
-end
-
-#=
-Specializations for splitting with groups
-=#
-
-function gc_eosparam_split_model(Base.@nospecialize(params::EoSParam),groups::GroupParameter,comp_splitter,gc_splitter)
-    T = typeof(params)
-    function _split(parami::ClapeyronParam)
-        if parami.components == groups.components
-            return split_model(parami,comp_splitter)
-        elseif parami.components == groups.flattenedgroups
-            return split_model(parami,gc_splitter)
-        else
-            throw(error("$parami is in a GC model, but does not have compatible component names for either component-based or group-based splitting."))
-        end
-    end
-    _split(parami) = split_model(parami,gc_splitter)
-
-    split_paramsvals = (_split(getfield(params,i)) for i  ∈ fieldnames(T))
-    return T.(split_paramsvals...)
-end
-
-function group_splitter(group::GroupParam,splitter)
-    n = length(splitter)
-    group_split = Vector{GroupParam}(undef,n)
-    idx_split = Vector{Vector{Bool}}(undef,n)
-    flattenedgroups = group.flattenedgroups
-    gc_splitter = Vector{Vector{Int}}(undef,n)
-    m = length(group.flattenedgroups)
-    for i in 1:n
-        idxi,gi = gc_each_split_model(group,splitter[i])
-        idx_split[i] = idxi
-        group_split[i] = gi
-        gc_splitter[i] = findall(isone,idxi)::Vector{Int}
-    end
-    return group_split,idx_split,gc_splitter
-end
-
-function recalculate_site_translator!(sites::Vector{SiteParam},idx_splitter)
-    bool_to_int = Int[]
-    for i in 1:length(idx_splitter)
-        site_translator_i = sites[i].site_translator::Vector{Vector{NTuple{2,Int}}}
-        #the tuple is (ki,site_kia) where ki is the position of the group, and site_ki is the site number in GC based sites
-        #DO NOT use the second number. if you really need it, store the original SiteParam instead.
-        #the first number is used to reference the gc pair at an specific component, via get_group_idx
-
-        idxi = idx_splitter[i]
-        resize!(bool_to_int,length(idxi))
-        bool_to_int .= 0
-        wk = 0
-        for w in 1:length(idxi)
-            if idxi[w]
-                wk += 1
-                bool_to_int[w] = wk
-            end
-        end
-        for (l,s0) in pairs(site_translator_i)
-            si = copy(s0)
-            iszero(length(si)) && continue
-            for a in 1:length(si)
-                ki,_ = si[a]
-                ki_new = bool_to_int[ki] #splitted group new index, if not zero
-                si[a] = (ki_new,0)
-
-            end
-            site_translator_i[l] = filter!(x -> !iszero(first(x)),si)
-        end
-    end
-end
-#=
-Start of EoSModel split_model functions
-=#
-function split_model(model::EoSModel,splitter)
-    if is_splittable(model)
-        return auto_split_model(model,splitter)
-    else
-        return fill(model,length(splitter))
-    end
-end
-    
-function auto_split_model(Base.@nospecialize(model::EoSModel),subset)
-    try
-        allfields = Dict{Symbol,Any}()
-
-        M = typeof(model)
-        allfieldnames = fieldnames(M)
-
-        if subset === nothing
-            splitter = _n_splitter(length(model.components))
-        elseif eltype(subset) <: Integer
-            splitter = [Int(i):Int(i) for i in subset]
-        elseif eltype(subset) <: AbstractVector
-            splitter = subset
-        else
-            throw(ArgumentError("Invalid type of subset. Expected subset::AbstractVector{Union{Int,AbstractVector{Int}}} or subset::Nothing"))
-        end
-
-        len = length(splitter)
-        _has_groups = has_groups(M)
-        #shortcut for directly non-splittable models
-
-        if _has_groups
-            gc_split,idx_splitter,gc_splitter = group_splitter(model.groups,splitter)
-            allfields[:groups] = gc_split
-            allfields[:components] = split_model(model.groups.components::Vector{String},splitter)
-            comp_splitter = splitter
-            splitter = gc_splitter
-        else
-            comp_splitter = splitter
-            gc_splitter = splitter
-        end
-        #add here any special keys, that behave as non_splittable values
-        for modelkey in (:references,)
-            if modelkey in allfieldnames
-                if !haskey(allfields,modelkey)
-                    allfields[modelkey] = fill(getproperty(model,modelkey),len)
-                end
-            end
-        end
-
-        for modelkey ∈ allfieldnames
-            if !haskey(allfields,modelkey)
-                modelx = getproperty(model,modelkey)
-                if is_splittable(modelx)
-                    if modelx isa SiteParam && _has_groups && modelx.site_translator !== nothing
-                        #process site_translator
-                        split_sites = split_model(modelx,comp_splitter)
-                        recalculate_site_translator!(split_sites,idx_splitter)
-                        allfields[modelkey] = split_sites
-                    elseif modelx isa ClapeyronParam && _has_groups
-                        #in this particular case, we can suppose that we have the components field
-                        if modelx.components == model.groups.flattenedgroups
-                            allfields[modelkey] = split_model(modelx,gc_splitter)
-                        elseif modelx.components == model.groups.components
-                            allfields[modelkey] = split_model(modelx,comp_splitter)
-                        else
-                            throw(error("$modelx is in a GC model, but does not have compatible component names for either component-based or group-based splitting."))
-                        end
-                    elseif modelx isa EoSParam && _has_groups
-                        #we supppose a EoSParam has only one layer of splitting
-                        allfields[modelkey] = gc_eosparam_split_model(modelx,model.groups,comp_splitter,gc_splitter)
-                    else
-                        #we suppose that this can splitted on his own (EoSModels are here.)
-                        allfields[modelkey] = split_model(modelx,comp_splitter)
-                    end
-                else
-                    allfields[modelkey] = fill(modelx,len)
-                end
-            end
-        end
-
-        return [M((allfields[k][i] for k ∈ allfieldnames)...) for i ∈ 1:len]::Vector{M}
-    catch e
-        M = typeof(model)
-        @error "$M cannot be splitted"
-        rethrow(e)
-    end
-end
-
-##fallback,around 50 times slower if there is any need to read csvs
-
-function simple_split_model(Base.@nospecialize(model::EoSModel),subset = nothing)
-    MODEL = typeof(model)
-    pure = Vector{MODEL}(undef,0)
-    if subset === nothing
-        comps = model.components
-    else
-        comps = model.components[subset]
-    end
-    for comp ∈ comps
-        push!(pure,MODEL([comp]))
-    end
-    return pure
-end
 
 """
     split_model_binaries(model::EoSModel)::Vector{EoSModel}

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -358,6 +358,8 @@ function _split_model(param,splitter::AbstractVector{Int})
     end
 end
 
+_split_model(param,i::Int) = [each_split_model(param,i:i)]
+
 function _split_model(param,splitter::AbstractVector)
     if is_splittable(param)
         return map(Base.Fix1(each_split_model,param),splitter)

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -107,7 +107,7 @@ function each_split_model(assoc::Compressed4DMatrix{T},I) where T
     return Compressed4DMatrix(values,outer_indices,inner_indices,outer_size,inner_size)
 end
 
-function each_split_model(param::Union{SingleParameter,PairParameter,AssocParam},group,I_component,I_group)
+function each_split_model(param::ClapeyronParam,group,I_component,I_group)
     components = param.components
     if group === nothing
         return each_split_model(param,I_component)

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -23,7 +23,7 @@ end
         models2 = split_model(model2)
         @info "The following 2 error messages are expected:"
         @test_throws ArgumentError split_model(noparam1)
-        @test_throws ArgumentError split_model(model2,missing)
+        @test_throws MethodError split_model(model2,missing)
         @test models2[1].components[1] == model2.components[1]
         @test models2[2].components[1] == model2.components[2]
 


### PR DESCRIPTION
one of our main speed problems on multicomponent solvers was starting to be the model splitting. this should solve that problem once and for all.

For reference, before, we divided each param first and then joined together everything, recursing only at the EoSModel level. this PR adds a general recursion function (`each_split_model_struct`) that generates an optimal representation of how a struct should be split according to our rules. `EoSModels` then the `split_model` function just collects a vector of `each_split_model(model,I)` for each `I` in the splitter
```julia

julia> model = SAFTgammaMie(["water","acetone"])
SAFTgammaMie{BasicIdeal} with 2 components:
 "water": "H2O" => 1
 "acetone": "CH3COCH3" => 1
Group Type: SAFTgammaMie
Contains parameters: segment, shapefactor, lambda_a, lambda_r, sigma, epsilon, epsilon_assoc, bondvol

#before
julia> @btime split_model(model)
  58.800 μs (587 allocations: 44.53 KiB)
2-element Vector{SAFTgammaMie{BasicIdeal}}:
 SAFTgammaMie{BasicIdeal}("water")
 SAFTgammaMie{BasicIdeal}("acetone")

#after
julia> @btime split_model(model)
  18.000 μs (431 allocations: 22.47 KiB)
2-element Vector{SAFTgammaMie{BasicIdeal}}:
 SAFTgammaMie{BasicIdeal}("water")
 SAFTgammaMie{BasicIdeal}("acetone")
```