### PR TITLE
Parametric SAFTgammaMie

### DIFF
--- a/src/database/ClapeyronParam.jl
+++ b/src/database/ClapeyronParam.jl
@@ -72,6 +72,7 @@ function build_eosparam(::Type{T},data) where T <: ParametricEoSParam
 end
 
 Base.eltype(p::EoSParam) = Float64
+Base.eltype(p::ParametricEoSParam{T}) where T = T
 
 const PARSED_GROUP_VECTOR_TYPE = Vector{Tuple{String, Vector{Pair{String, Int64}}}}
 
@@ -132,15 +133,27 @@ function _convert_param(T::V,val::ReferenceState) where V
     return val
 end
 
-function _convert_param(T::V,::Type{SingleParameter},val) where V
+function _convert_param(T::V,::Type{SingleParameter{V}},val) where V
+    return val
+end
+
+function _convert_param(T::V,::Type{PairParameter{V}},val) where V
+    return val
+end
+
+function _convert_param(T::V,::Type{AssocParam{V}},val) where V
+    return val
+end
+
+function _convert_param(T::V,::Type{SingleParameter{V2}},val) where {V,V2}
     return convert(SingleParam{T},val)
 end
 
-function _convert_param(T::V,::Type{PairParameter},val) where V
+function _convert_param(T::V,::Type{PairParameter{V2}},val) where {V,V2}
     return convert(PairParam{T},val)
 end
 
-function _convert_param(T::V,::Type{AssocParam},val) where V
+function _convert_param(T::V,::Type{AssocParam{V2}},val) where {V,V2}
     return convert(AssocParam{T},val)
 end
 

--- a/src/database/ClapeyronParam.jl
+++ b/src/database/ClapeyronParam.jl
@@ -148,36 +148,44 @@ function _convert_param(T::V,val) where V
     return _convert_param(T,parameterless_type(val),val)
 end
 
-function _convert_param(T::V,val::SpecialComp) where V
+function _convert_param(T::Type{V},val::SpecialComp) where V
     return val
 end
 
-function _convert_param(T::V,val::ReferenceState) where V
+function _convert_param(T::Type{V},val::ReferenceState) where V
     return val
 end
 
-function _convert_param(T::V,::Type{SingleParameter},val::SingleParameter{V}) where V
+function _convert_param(T::Type{V},::Type{SingleParameter},val::SingleParameter{V}) where V
     return val
 end
 
-function _convert_param(T::V,::Type{PairParameter},val::PairParameter{V}) where V
+function _convert_param(T::Type{V},::Type{PairParameter},val::PairParameter{V}) where V
     return val
 end
 
-function _convert_param(T::V,::Type{AssocParam},val::AssocParam{V}) where V
+function _convert_param(T::Type{V},::Type{AssocParam},val::AssocParam{V}) where V
     return val
 end
 
-function _convert_param(T::V,::Type{SingleParameter},val) where {V}
+function _convert_param(T::Type{V},::Type{MixedGCSegmentParam},val::MixedGCSegmentParam{V}) where V
+    return val
+end
+
+function _convert_param(T::Type{V},::Type{SingleParameter},val) where {V}
     return convert(SingleParam{T},val)
 end
 
-function _convert_param(T::V,::Type{PairParameter},val) where {V}
+function _convert_param(T::Type{V},::Type{PairParameter},val) where {V}
     return convert(PairParam{T},val)
 end
 
-function _convert_param(T::V,::Type{AssocParam},val) where {V}
+function _convert_param(T::Type{V},::Type{AssocParam},val) where {V}
     return convert(AssocParam{T},val)
+end
+
+function _convert_param(T::Type{V},::Type{MixedGCSegmentParam},val) where {V}
+    return convert(MixedGCSegmentParam{T},val)
 end
 
 const SingleOrPair = Union{<:SingleParameter,<:PairParameter}

--- a/src/database/ClapeyronParam.jl
+++ b/src/database/ClapeyronParam.jl
@@ -52,7 +52,12 @@ end
     expr = :($paramname{$TT}())
     args = expr.args
     for i in 1:paramlength
-        push!(args,:(_convert_param($TT,args[$i])))
+        paramtype = fieldtype(P,i)
+        if isconcretetype(paramtype)
+            push!(args,:(convert($paramtype,args[$i])))
+        else
+            push!(args,:(_convert_param($TT,args[$i])))
+        end
     end
     return expr
 end

--- a/src/database/combiningrules.jl
+++ b/src/database/combiningrules.jl
@@ -129,7 +129,8 @@ Ignores non-diagonal entries already set.
 If a Single Parameter is passed as input, it will be converted to a Pair Parameter with `λᵢᵢ = λᵢ`.
 """
 function lambda_LorentzBerthelot(lambda::SingleOrPair,k = 3)
-    return return lambda_LorentzBerthelot!(PairParam(lambda),k)
+    param = PairParam(lambda.name,lambda.components,float.(lambda.values),lambda.ismissingvalues,lambda.sourcecsvs,lambda.sources)
+    return lambda_LorentzBerthelot!(param,k)
 end
 
 

--- a/src/database/combiningrules/outplace.jl
+++ b/src/database/combiningrules/outplace.jl
@@ -19,8 +19,9 @@ Ignores non-diagonal entries already set.
 
 If a Single Parameter is passed as input, it will be converted to a Pair Parameter with `pᵢᵢ = pᵢ`.
 """
-function kij_mix(f::F,param::SingleOrPair,K = nothing) where F
-    return kij_mix!(f,PairParam(param),K)
+function kij_mix(f::F,P::SingleOrPair,K = nothing) where F
+    param = PairParam(P.name,P.components,float.(P.values),P.ismissingvalues,P.sourcecsvs,P.sources)
+    return kij_mix!(f,param,K)
 end
 
 
@@ -45,5 +46,6 @@ If you pass a `SingleParam` or a vector as input for `Q`, then `Qᵢⱼ` will be
 ```
 """
 function pair_mix(f::F,P::SingleOrPair,Q::SingleOrPair) where F
-    return pair_mix!(f,PairParam(P),Q)
+    param = PairParam(P.name,P.components,float.(P.values),P.ismissingvalues,P.sourcecsvs,P.sources)
+    return pair_mix!(f,param,Q)
 end

--- a/src/database/params/AssocParam.jl
+++ b/src/database/params/AssocParam.jl
@@ -82,6 +82,7 @@ function Base.copyto!(dest::AssocParam,src::AssocParam) #used to set params
 end
 
 Base.eltype(param::AssocParam{T}) where T = T
+Base.eltype(param::Type{<:AssocParam{T}}) where T = T
 
 Base.size(param::AssocParam) = size(param.values.values)
 

--- a/src/database/params/AssocParam.jl
+++ b/src/database/params/AssocParam.jl
@@ -186,28 +186,14 @@ end
 #convert utilities
 function Base.convert(::Type{AssocParam{T1}},param::AssocParam{T2}) where {T1<:Number,T2<:Number}
     assoc_values = param.values
-    new_assoc_values = T1.(assoc_values.values)
+    new_assoc_values = convert(Vector{T1},assoc_values.values)
     values = Compressed4DMatrix(new_assoc_values,assoc_values.outer_indices,assoc_values.inner_indices,assoc_values.outer_size,assoc_values.inner_size)
-    return AssocParam(param.name,param.components,values,param.sites,param.sourcecsvs,param.sources)
-end
-
-function Base.convert(::Type{AssocParam{Bool}},param::AssocParam{<:Union{Int,Float64}})
-    assoc_values = param.values
-    #@assert all(z->(isone(z) | iszero(z)),assoc_values.values)
-    new_assoc_values = Array(Bool.(assoc_values.values))
-    values = Compressed4DMatrix(new_assoc_values,assoc_values.outer_indices,assoc_values.inner_indices,assoc_values.outer_size,assoc_values.inner_size)
-
     return AssocParam(param.name,param.components,values,param.sites,param.sourcecsvs,param.sources)
 end
 
 function Base.convert(::Type{AssocParam{String}},param::AssocParam{<:AbstractString})
     assoc_values = param.values
-    new_assoc_values = String.(assoc_values.values)
+    new_assoc_values = convert(Vector{String},assoc_values.values)
     values = Compressed4DMatrix(new_assoc_values,assoc_values.outer_indices,assoc_values.inner_indices,assoc_values.outer_size,assoc_values.inner_size)
     return AssocParam(param.name,param.components,values,param.sites,param.sourcecsvs,param.sources)
-end
-
-#trying to break stack overflow on julia 1.6
-function Base.convert(::Type{AssocParam{String}},param::AssocParam{String})
-    return param
 end

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -278,3 +278,10 @@ function MixedGCSegmentParam(group::GroupParam,s = FillArrays.Fill(1.0,length(gr
     mix_segment!(group_cache,s,segment)
     return group_cache
 end
+
+function Base.convert(::Type{MixedGCSegmentParam{T1}},param::MixedGCSegmentParam{T2}) where {T1<:Number,T2<:Number}
+    p,v1 = param.values.p,param.values.v
+    v = T1.(v1)
+    values = PackedVofV(p,v)
+    return SingleParam(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
+end

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -281,7 +281,7 @@ end
 
 function Base.convert(::Type{MixedGCSegmentParam{T1}},param::MixedGCSegmentParam{T2}) where {T1<:Number,T2<:Number}
     p,v1 = param.values.p,param.values.v
-    v = T1.(v1)
+    v = convert(Vector{T1},v1)
     values = PackedVofV(p,v)
     return SingleParam(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
 end

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -238,10 +238,31 @@ end
 
 MixedGCSegmentParam(name,components) = MixedGCSegmentParam{Float64}(name,components,PackedVofV(Int[],Float64[]))
 
-Base.eltype(::MixedGCSegmentParam{T}) where T = SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int64}}, true}
+Base.length(param::MixedGCSegmentParam) = length(param.values)
+
+Base.eltype(param::MixedGCSegmentParam) = eltype(typeof(param))
+Base.eltype(param::Type{MixedGCSegmentParam{T}}) where T = SubArray{T, 1, Vector{T}, Tuple{UnitRange{Int64}}, true}
+
+paramtype(::MixedGCSegmentParam{T}) where T = T
+paramtype(::Type{MixedGCSegmentParam{T}}) where T = T
+
+Base.getindex(param::MixedGCSegmentParam,i) = param.values[i]
+
+function Base.show(io::IO,param::MixedGCSegmentParam)
+    print(io, typeof(param), "(\"", param.name, "\")")
+    show(io,param.components)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", param::MixedGCSegmentParam)
+    len = length(param.values)
+    print(io, "MixedGCSegmentParam{",eltype(param.values.v), "}(\"", param.name)
+    println(io, "\") with ", len, " component", ifelse(len==1, ":", "s:"))
+    separator = " => "
+    show_pairs(io,param.components,param.values,separator)
+end
 
 function MixedGCSegmentParam(group::GroupParam,s = FillArrays.Fill(1.0,length(groups.flattenedgroups)),segment = FillArrays.Fill(1.0,length(groups.flattenedgroups)))
-    name = "group cache"
+    name = "mixed segment"
     components = group.components
     nc = length(components)
     ng = length(group.flattenedgroups)

--- a/src/database/params/PairParam.jl
+++ b/src/database/params/PairParam.jl
@@ -119,6 +119,7 @@ end
 Base.size(param::PairParameter) = size(param.values)
 
 Base.eltype(param::PairParameter{T}) where T = T
+Base.eltype(param::Type{<:PairParameter{T}}) where T = T
 
 #primalval
 function Solvers.primalval(x::PairParameter)

--- a/src/database/params/PairParam.jl
+++ b/src/database/params/PairParam.jl
@@ -218,13 +218,7 @@ end
 
 #convert utilities
 function Base.convert(::Type{PairParam{T1}},param::PairParam{T2}) where {T1<:Number,T2<:Number}
-    values = T1.(param.values)
-    return PairParam(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
-end
-
-function Base.convert(::Type{PairParam{Bool}},param::PairParam{<:Union{Int,Float64,Bool}})
-    #@assert all(z->(isone(z) | iszero(z)),param.values)
-    values = Array(Bool.(param.values))
+    values = convert(Matrix{T1},param.values)
     return PairParam(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
 end
 

--- a/src/database/params/PairParam.jl
+++ b/src/database/params/PairParam.jl
@@ -132,6 +132,17 @@ function PairParam(name,components,values::Matrix{T},missingvals,src,sourcecsv) 
     PairParameter{T,Matrix{T}}(name,components,values,missingvals,src,sourcecsv)
 end
 
+function PairParam(name,components,values::Vector{T},missingvals::Vector,src,sourcecsv) where T 
+    n = length(values)
+    mat_values = zeros(T,(n,n))
+    mat_missing = ones(Bool,(n,n))
+    for i in 1:n
+        mat_values[i,i] = values[i]
+        mat_missing[i,i] = false
+    end
+    PairParam(name,components,mat_values,mat_missing,src,sourcecsv)
+end
+
 function PairParam(name,components,values::AbstractMatrix{T},missingvals,src,sourcecsv) where T 
     return PairParam(name,components,convert(Matrix{T},values),missingvals,src,sourcecsv)
 end

--- a/src/database/params/ReferenceState.jl
+++ b/src/database/params/ReferenceState.jl
@@ -117,7 +117,7 @@ function Base.show(io::IO,::MIME"text/plain",ref::ReferenceState)
 end
 
 #for compatibility in parametric params.
-Base.eltype(ref::ReferenceState) = Float64
+Base.eltype(::Type{ReferenceState}) = Float64
 
 #by default, the reference state is stored in the idealmodel params. unwrap until
 #reaching that

--- a/src/database/params/SingleParam.jl
+++ b/src/database/params/SingleParam.jl
@@ -97,6 +97,7 @@ function Solvers.primalval(x::SingleParameter)
 end
 
 Base.eltype(param::SingleParameter{T}) where T = T
+Base.eltype(param::Type{<:SingleParameter{T}}) where T = T
 
 #linear algebra
 

--- a/src/database/params/SingleParam.jl
+++ b/src/database/params/SingleParam.jl
@@ -164,24 +164,13 @@ end
 
 #convert utilities
 function Base.convert(::Type{SingleParam{T1}},param::SingleParam{T2}) where {T1<:Number,T2<:Number}
-    values = T1.(param.values)
-    return SingleParam(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
-end
-
-function Base.convert(::Type{SingleParam{Bool}},param::SingleParam{<:Union{Int,Float64,Bool}})
-    #@assert all(z->(isone(z) | iszero(z)),param.values)
-    values = Array(Bool.(param.values))
+    values = convert(Vector{T1},param.values)
     return SingleParam(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
 end
 
 function Base.convert(::Type{SingleParam{String}},param::SingleParam{<:AbstractString})
-    values = String.(param.values)
+    values = convert(Vector{String},param.values)
     return SingleParameter(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
-end
-
-#trying to break stack overflow on julia 1.6
-function Base.convert(::Type{SingleParam{String}},param::SingleParam{String})
-    return param
 end
 
 #pack vectors

--- a/src/database/params/SingleParam.jl
+++ b/src/database/params/SingleParam.jl
@@ -113,6 +113,18 @@ function SingleParam(name,components,values::AbstractVector{T},missingvals,src,s
     return SingleParam(name,components,convert(Vector{T},values),missingvals,src,sourcecsv)
 end
 
+function SingleParam(name,components,values::Matrix{T},missingvals::Matrix{Bool},src,sourcecsv) where T 
+    n = length(components)
+    vec_values = zeros(T,n)
+    vec_missing = zeros(Bool,n)
+    for i in 1:n
+        vec_values[i] = values[i,i]
+        vec_missing[i] = missingvals[i,i]
+    end
+
+    return SingleParam(name,components,vec_values,vec_missing,src,sourcecsv)
+end
+
 SingleParam(name,components,values,missingvals,src) = SingleParam(name,components,values,missingvals,src,nothing)
 SingleParam(name,components,values,missingvals) = SingleParam(name,components,values,missingvals,nothing,nothing)
 

--- a/src/methods/property_solvers/singlecomponent/crit_pure.jl
+++ b/src/methods/property_solvers/singlecomponent/crit_pure.jl
@@ -26,18 +26,46 @@ function crit_pure(model::EoSModel,x0;options = NEqOptions())
     #end
     _1 = oneunit(T̄)
     #x0 = SVector(_1*x01,_1*x02)
-    x0 = vec2(x01,x02*log(10),_1)
-    f!(F,x) = ObjCritPure(model,F,T̄,x)
+    x0 = vec2(primalval(x01),primalval(x02*log(10)),primalval(_1))
+    primalmodel = primalval(model)
+    f!(F,x) = ObjCritPure(primalmodel,F,primalval(T̄),x)
     solver_res = Solvers.nlsolve(f!, x0, TrustRegion(Newton(), NLSolvers.NWI()), options)
     #display(solver_res)
     r  = Solvers.x_sol(solver_res)
     T_c = r[1]*T̄
     V_c = exp(r[2])
     p_c = pressure(model, V_c, T_c)
-    return (T_c, p_c, V_c)
+
+    crit = (T_c, p_c, V_c)
+    return crit_pure_ad(model,crit)
+end
+
+function crit_pure_ad(model,crit)
+    if has_dual(model)
+        T_c_primal, p_c_primal, V_c_primal = crit
+        T̄  = T_scale(model)
+        x = SVector(T_c_primal/T̄,log(V_c_primal))
+        f(z) = __ObjCritPure(model,T̄,z)
+        F,J = Solvers.J2(f,x)
+        ∂x = J\F
+        r = x .- ∂x
+        T_c = r[1]*T̄
+        V_c = exp(r[2])
+        P_c = pressure(model,V_c,T_c)
+        return (T_c,P_c,V_c)
+    else
+        return crit
+    end
 end
 
 function ObjCritPure(model::T,F,T̄,x) where T
+    sv = __ObjCritPure(model,T̄,x)
+    F[1] = sv[1]
+    F[2] = sv[2]
+    return F
+end
+
+function __ObjCritPure(model::T,T̄,x) where T
     T_c = x[1]*T̄
     V_c = exp(x[2])
     RT = Rgas(model)*T_c
@@ -46,6 +74,5 @@ function ObjCritPure(model::T,F,T̄,x) where T
     ∂²A∂V², ∂³A∂V³ = ∂²³f(model, V_c, T_c, SA[1.0])
     F1 = -∂²A∂V²*∂²A∂V²_scale
     F2 = -∂³A∂V³*∂³A∂V³_scale
-    #return SVector(F1,F2)
-    F[1] = F1;F[2] = F2; return F
+    return SVector((F1,F2))
 end

--- a/src/models/Activity/UNIFAC/UNIFAC.jl
+++ b/src/models/Activity/UNIFAC/UNIFAC.jl
@@ -281,7 +281,7 @@ function excess_g_res(model::UNIFACModel,p,T,z)
     Q = model.params.Q.values
     ∑vikQk = [dot(Q,vi) for vi in v]
     #calculate Θ with the least amount of allocs possible
-    X = group_matrix(model.groups)*z
+    X = group_fractions(model.groups,z)
     ∑XQ⁻¹ = 1/dot(X,Q)
     X .*= Q
     X .*= ∑XQ⁻¹

--- a/src/models/Electrolytes/Ion/GCMSABorn.jl
+++ b/src/models/Electrolytes/Ion/GCMSABorn.jl
@@ -49,7 +49,7 @@ function GCMSABorn(solvents,ions; RSPmodel=ConstRSP, userlocations=String[],RSPm
     segment = params["vst"]
     shapefactor = params["S"]
 
-    mix_segment!(groups,shapefactor.values,segment.values)
+    #mix_segment!(groups,shapefactor.values,segment.values)
 
     sigma = params["sigma"]
 

--- a/src/models/SAFT/PCSAFT/PCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/PCSAFT.jl
@@ -11,8 +11,6 @@ function PCSAFTParam(Mw,segment,sigma,epsilon,epsilon_assoc,bondvol)
     return build_parametric_param(PCSAFTParam,Mw,segment,sigma,epsilon,epsilon_assoc,bondvol)
 end
 
-Base.eltype(p::PCSAFTParam{T}) where T = T
-
 abstract type PCSAFTModel <: SAFTModel end
 @newmodel PCSAFT PCSAFTModel PCSAFTParam{T}
 default_references(::Type{PCSAFT}) = ["10.1021/ie0003887", "10.1021/ie010954d"]

--- a/src/models/SAFT/PCSAFT/variants/CPPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/CPPCSAFT.jl
@@ -1,5 +1,18 @@
+struct CPPCSAFTParam{T} <: ParametricEoSParam{T}
+    Mw::SingleParam{T}
+    segment::PairParam{T}
+    sigma::PairParam{T}
+    epsilon::PairParam{T}
+    epsilon_assoc::AssocParam{T}
+    bondvol::AssocParam{T}
+end
+
+function CPPCSAFTParam(Mw,segment,sigma,epsilon,epsilon_assoc,bondvol)
+    return build_parametric_param(CPPCSAFTParam,Mw,segment,sigma,epsilon,epsilon_assoc,bondvol)
+end
+
 abstract type CPPCSAFTModel <: PCSAFTModel end
-@newmodel CPPCSAFT CPPCSAFTModel PCSAFTParam{T}
+@newmodel CPPCSAFT CPPCSAFTModel CPPCSAFTParam{T}
 export CPPCSAFT
 
 """

--- a/src/models/SAFT/PCSAFT/variants/CPPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/CPPCSAFT.jl
@@ -1,15 +1,5 @@
-struct CPPCSAFTParam <: EoSParam
-    Mw::SingleParam{Float64}
-    segment::PairParam{Float64}
-    sigma::PairParam{Float64}
-    epsilon::PairParam{Float64}
-    delta::SingleParam{Float64}
-    epsilon_assoc::AssocParam{Float64}
-    bondvol::AssocParam{Float64}
-end
-
 abstract type CPPCSAFTModel <: PCSAFTModel end
-@newmodel CPPCSAFT CPPCSAFTModel CPPCSAFTParam
+@newmodel CPPCSAFT CPPCSAFTModel PCSAFTParam{T}
 export CPPCSAFT
 
 """
@@ -28,7 +18,6 @@ export CPPCSAFT
 - `segment`: Single Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Single Parameter (`Float64`) - Segment Diameter [`A°`]
 - `epsilon`: Single Parameter (`Float64`) - Reduced dispersion energy  `[K]`
-- `delta`: Single Parameter (`Float64`) - Critical volume displacement (no units)
 - `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Paramater (no units)
 - `epsilon_assoc`: Association Parameter (`Float64`) - Reduced association energy `[K]`
 - `bondvol`: Association Parameter (`Float64`) - Association Volume `[m^3]`
@@ -37,7 +26,6 @@ export CPPCSAFT
 - `segment`: Pair Parameter (`Float64`) - Number of segments (no units)
 - `sigma`: Pair Parameter (`Float64`) - Mixed segment Diameter `[m]`
 - `epsilon`: Pair Parameter (`Float64`) - Mixed reduced dispersion energy`[K]`
-- `delta`: Single Parameter (`Float64`) - Critical volume displacement (no units)
 - `epsilon_assoc`: Association Parameter (`Float64`) - Reduced association energy `[K]`
 - `bondvol`: Association Parameter (`Float64`) - Association Volume
 ## Input models

--- a/src/models/SAFT/PCSAFT/variants/PCPSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/PCPSAFT.jl
@@ -1,16 +1,20 @@
-struct PCPSAFTParam <: EoSParam
-    Mw::SingleParam{Float64}
-    segment::SingleParam{Float64}
-    sigma::PairParam{Float64}
-    epsilon::PairParam{Float64}
-    dipole::SingleParam{Float64}
-    dipole2::SingleParam{Float64}
-    epsilon_assoc::AssocParam{Float64}
-    bondvol::AssocParam{Float64}
+struct PCPSAFTParam{T} <: ParametricEoSParam{T}
+    Mw::SingleParam{T}
+    segment::SingleParam{T}
+    sigma::PairParam{T}
+    epsilon::PairParam{T}
+    dipole::SingleParam{T}
+    dipole2::SingleParam{T}
+    epsilon_assoc::AssocParam{T}
+    bondvol::AssocParam{T}
+end
+
+function PCPSAFTParam(Mw,segment,sigma,epsilon,dipole,dipole2,epsilon_assoc,bondvol)
+    return build_parametric_param(PCPSAFTParam,Mw,segment,sigma,epsilon,dipole,dipole2,epsilon_assoc,bondvol)
 end
 
 abstract type PCPSAFTModel <: PCSAFTModel end
-@newmodel PCPSAFT PCPSAFTModel PCPSAFTParam
+@newmodel PCPSAFT PCPSAFTModel PCPSAFTParam{T}
 
 #=
 at the moment, we use the Gross-Vrabec polar term

--- a/src/models/SAFT/PCSAFT/variants/PharmaPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/PharmaPCSAFT.jl
@@ -1,17 +1,22 @@
-struct pharmaPCSAFTParam <: EoSParam
-    Mw::SingleParam{Float64}
-    segment::SingleParam{Float64}
-    sigma::PairParam{Float64}
-    epsilon::PairParam{Float64}
-    k::PairParam{Float64}
-    kT::PairParam{Float64}
-    epsilon_assoc::AssocParam{Float64}
-    bondvol::AssocParam{Float64}
+struct pharmaPCSAFTParam{T} <: ParametricEoSParam{T}
+    Mw::SingleParam{T}
+    segment::SingleParam{T}
+    sigma::PairParam{T}
+    epsilon::PairParam{T}
+    k::PairParam{T}
+    kT::PairParam{T}
+    epsilon_assoc::AssocParam{T}
+    bondvol::AssocParam{T}
     water::SpecialComp
 end
 
 abstract type pharmaPCSAFTModel <: PCSAFTModel end
-@newmodel pharmaPCSAFT pharmaPCSAFTModel pharmaPCSAFTParam
+@newmodel pharmaPCSAFT pharmaPCSAFTModel pharmaPCSAFTParam{T}
+
+function pharmaPCSAFTParam(Mw,m,σ,ϵ,k,kT,ϵijab,β,water)
+    return build_parametric_param(pharmaPCSAFTParam,Mw,m,σ,ϵ,k,kT,ϵijab,β,water)
+end
+
 default_references(::Type{pharmaPCSAFT}) = ["10.1021/ie0003887", "10.1021/ie010954d","10.1016/j.cep.2007.02.034"]
 default_locations(::Type{pharmaPCSAFT}) = ["SAFT/PCSAFT","SAFT/PCSAFT/pharmaPCSAFT","properties/molarmass.csv"]
 default_assoc_options(::Type{pharmaPCSAFT}) = AssocOptions(combining = :elliott_runtime)

--- a/src/models/SAFT/PCSAFT/variants/QPCPSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/QPCPSAFT.jl
@@ -1,14 +1,14 @@
-struct QPCPSAFTParam <: ParametricEoSParam{T}
-    Mw::SingleParam{Float64}
-    segment::SingleParam{Float64}
-    sigma::PairParam{Float64}
-    epsilon::PairParam{Float64}
-    dipole::SingleParam{Float64}
-    dipole2::SingleParam{Float64}
-    quadrupole::SingleParam{Float64}
-    quadrupole2::SingleParam{Float64}
-    epsilon_assoc::AssocParam{Float64}
-    bondvol::AssocParam{Float64}
+struct QPCPSAFTParam{T} <: ParametricEoSParam{T}
+    Mw::SingleParam{T}
+    segment::SingleParam{T}
+    sigma::PairParam{T}
+    epsilon::PairParam{T}
+    dipole::SingleParam{T}
+    dipole2::SingleParam{T}
+    quadrupole::SingleParam{T}
+    quadrupole2::SingleParam{T}
+    epsilon_assoc::AssocParam{T}
+    bondvol::AssocParam{T}
 end
 
 abstract type QPCPSAFTModel <: PCPSAFTModel end

--- a/src/models/SAFT/PCSAFT/variants/QPCPSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/QPCPSAFT.jl
@@ -1,4 +1,4 @@
-struct QPCPSAFTParam <: EoSParam
+struct QPCPSAFTParam <: ParametricEoSParam{T}
     Mw::SingleParam{Float64}
     segment::SingleParam{Float64}
     sigma::PairParam{Float64}
@@ -12,7 +12,12 @@ struct QPCPSAFTParam <: EoSParam
 end
 
 abstract type QPCPSAFTModel <: PCPSAFTModel end
-@newmodel QPCPSAFT QPCPSAFTModel QPCPSAFTParam
+@newmodel QPCPSAFT QPCPSAFTModel QPCPSAFTParam{T}
+
+function QPCPSAFTParam(Mw,m,σ,ϵ,μ,μ2,Q,Q2,ϵijab,β)
+    return build_parametric_param(QPCPSAFTParam,Mw,m,σ,ϵ,μ,μ2,Q,Q2,ϵijab,β)
+end
+
 default_references(::Type{QPCPSAFT}) = ["10.1002/aic.10502","10.1021/jp072619u"]
 default_locations(::Type{QPCPSAFT}) = ["SAFT/PCSAFT/QPCPSAFT/","properties/molarmass.csv"] # Needs to add data for QPCPSAFT
 function transform_params(::Type{QPCPSAFT},params,components)

--- a/src/models/SAFT/PCSAFT/variants/gcPCPSAFT/heterogcPCPSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/gcPCPSAFT/heterogcPCPSAFT.jl
@@ -1,21 +1,25 @@
 
 abstract type gcPCPSAFTModel <: PCPSAFTModel end
 
-struct HeterogcPCPSAFTParam <: EoSParam
-    Mw::SingleParam{Float64}
-    segment::SingleParam{Float64}
-    sigma::PairParam{Float64}
-    epsilon::PairParam{Float64}
-    comp_segment::SingleParam{Float64}
-    comp_sigma::PairParam{Float64}
-    comp_epsilon::PairParam{Float64}
-    dipole::SingleParam{Float64}
-    dipole2::SingleParam{Float64}
-    epsilon_assoc::AssocParam{Float64}
-    bondvol::AssocParam{Float64}
+struct HeterogcPCPSAFTParam{T} <: ParametricEoSParam{T}
+    Mw::SingleParam{T}
+    segment::SingleParam{T}
+    sigma::PairParam{T}
+    epsilon::PairParam{T}
+    comp_segment::SingleParam{T}
+    comp_sigma::PairParam{T}
+    comp_epsilon::PairParam{T}
+    dipole::SingleParam{T}
+    dipole2::SingleParam{T}
+    epsilon_assoc::AssocParam{T}
+    bondvol::AssocParam{T}
 end
 
-@newmodelgc HeterogcPCPSAFT gcPCPSAFTModel HeterogcPCPSAFTParam true
+function HeterogcPCPSAFTParam(Mw,m,σ,ϵ,mc,σc,ϵc,μ,μ2,ϵijab,β)
+    return build_parametric_param(HeterogcPCPSAFTParam,Mw,m,σ,ϵ,mc,σc,ϵc,μ,μ2,ϵijab,β)
+end
+
+@newmodelgc HeterogcPCPSAFT gcPCPSAFTModel HeterogcPCPSAFTParam{T} true
 default_references(::Type{HeterogcPCPSAFT}) = ["10.1021/ie0003887", "10.1021/ie010954d"]
 default_locations(::Type{HeterogcPCPSAFT}) = ["SAFT/PCSAFT/gcPCPSAFT/hetero/","properties/molarmass_groups.csv"]
 default_gclocations(::Type{HeterogcPCPSAFT}) = ["SAFT/PCSAFT/gcPCPSAFT/hetero/HeterogcPCPSAFT_groups.csv","SAFT/PCSAFT/gcPCPSAFT/hetero/HeterogcPCPSAFT_intragroups.csv"]

--- a/src/models/SAFT/PCSAFT/variants/gcPCPSAFT/homogcPCPSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/gcPCPSAFT/homogcPCPSAFT.jl
@@ -1,12 +1,12 @@
 
 abstract type HomogcPCPSAFTModel <: PCPSAFTModel end
-struct HomogcPCPSAFT{I} <: HomogcPCPSAFTModel
+struct HomogcPCPSAFT{I,T} <: HomogcPCPSAFTModel
     components::Vector{String}
     groups::GroupParam
     sites::SiteParam
-    params::PCPSAFTParam
+    params::PCPSAFTParam{T}
     idealmodel::I
-    ppcmodel::PCPSAFT{I}
+    ppcmodel::PCPSAFT{I,T}
     assoc_options::AssocOptions
     references::Array{String,1}
 end

--- a/src/models/SAFT/PCSAFT/variants/gcsPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/gcsPCSAFT.jl
@@ -1,12 +1,12 @@
 abstract type gcsPCSAFTModel <: sPCSAFTModel end
 
-struct gcsPCSAFTParam <: ParametricEoSParam{T}
-    Mw::SingleParam{Float64}
-    segment::SingleParam{Float64}
-    msigma3::SingleParam{Float64}
-    mepsilon::SingleParam{Float64}
-    epsilon_assoc::AssocParam{Float64}
-    bondvol::AssocParam{Float64}
+struct gcsPCSAFTParam{T} <: ParametricEoSParam{T}
+    Mw::SingleParam{T}
+    segment::SingleParam{T}
+    msigma3::SingleParam{T}
+    mepsilon::SingleParam{T}
+    epsilon_assoc::AssocParam{T}
+    bondvol::AssocParam{T}
 end
 
 function gcsPCSAFTParam(Mw,m,mσ3,mϵ,ϵijab,β)

--- a/src/models/SAFT/PCSAFT/variants/gcsPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/gcsPCSAFT.jl
@@ -1,6 +1,6 @@
 abstract type gcsPCSAFTModel <: sPCSAFTModel end
 
-struct gcsPCSAFTParam <: EoSParam
+struct gcsPCSAFTParam <: ParametricEoSParam{T}
     Mw::SingleParam{Float64}
     segment::SingleParam{Float64}
     msigma3::SingleParam{Float64}
@@ -9,13 +9,17 @@ struct gcsPCSAFTParam <: EoSParam
     bondvol::AssocParam{Float64}
 end
 
-struct gcsPCSAFT{I,PC} <: gcsPCSAFTModel
+function gcsPCSAFTParam(Mw,m,mσ3,mϵ,ϵijab,β)
+    return build_parametric_param(gcsPCSAFTParam,Mw,m,mσ3,mϵ,ϵijab,β)
+end
+
+struct gcsPCSAFT{I,T} <: gcsPCSAFTModel
     components::Vector{String}
     groups::GroupParam
     sites::SiteParam
-    params::gcsPCSAFTParam
+    params::gcsPCSAFTParam{T}
     idealmodel::I
-    pcsaftmodel::PC
+    pcsaftmodel::PCSAFT{I,T}
     assoc_options::AssocOptions
     references::Array{String,1}
 end

--- a/src/models/SAFT/PCSAFT/variants/gcsPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/gcsPCSAFT.jl
@@ -19,7 +19,7 @@ struct gcsPCSAFT{I,T} <: gcsPCSAFTModel
     sites::SiteParam
     params::gcsPCSAFTParam{T}
     idealmodel::I
-    pcsaftmodel::PCSAFT{I,T}
+    pcsaftmodel::sPCSAFT{I,T}
     assoc_options::AssocOptions
     references::Array{String,1}
 end

--- a/src/models/SAFT/PCSAFT/variants/sPCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/sPCSAFT.jl
@@ -1,5 +1,5 @@
 abstract type sPCSAFTModel <: PCSAFTModel end
-@newmodel sPCSAFT sPCSAFTModel PCSAFTParam
+@newmodel sPCSAFT sPCSAFTModel PCSAFTParam{T}
 default_references(::Type{sPCSAFT}) = ["10.1021/ie020753p"]
 default_locations(::Type{sPCSAFT}) = ["SAFT/PCSAFT", "SAFT/PCSAFT/sPCSAFT"]
 function transform_params(::Type{sPCSAFT},params)

--- a/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
+++ b/src/models/SAFT/SAFTVRMie/SAFTVRMie.jl
@@ -13,8 +13,6 @@ function SAFTVRMieParam(Mw,segment,sigma,lambda_a,lambda_r,epsilon,epsilon_assoc
     return build_parametric_param(SAFTVRMieParam,Mw,segment,sigma,lambda_a,lambda_r,epsilon,epsilon_assoc,bondvol) 
 end
 
-Base.eltype(p::SAFTVRMieParam{T}) where T = T
-
 abstract type SAFTVRMieModel <: SAFTModel end
 @newmodel SAFTVRMie SAFTVRMieModel SAFTVRMieParam{T}
 default_references(::Type{SAFTVRMie}) = ["10.1063/1.4819786", "10.1080/00268976.2015.1029027"]

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -66,6 +66,7 @@ SAFTgammaMie(components;
 - `epsilon`: Pair Parameter (`Float64`) - Mixed reduced dispersion energy`[K]`
 - `epsilon_assoc`: Association Parameter (`Float64`) - Reduced association energy `[K]`
 - `bondvol`: Association Parameter (`Float64`) - Association Volume
+- `mixed_segment`: Mixed Group Contribution Parameter: ∑nᵢₖνₖmₖ
 
 ## Input models
 - `idealmodel`: Ideal Model

--- a/src/models/SAFT/SAFTgammaMie/equations.jl
+++ b/src/models/SAFT/SAFTgammaMie/equations.jl
@@ -75,11 +75,9 @@ function packing_fraction(model::SAFTgammaMieModel,_data::Tuple)
 end
 
 function X_gc(model::SAFTgammaMieModel,V,T,z)
-    mi  = group_matrix(model.groups)::Matrix{Float64}
+    nms = model.params.mixed_segment
+    X  = group_fractions(nms,z)
     mm = model.params.segment.values
-    TT = Base.promote_eltype(mm,1.0,z)
-    X = Vector{TT}(undef,length(model.groups.flattenedgroups))
-    mul!(X,mi,z)
     X ./= mm
     return X
 end
@@ -87,7 +85,7 @@ end
 function d_gc_av(model::SAFTgammaMieModel,V,T,z,_d_gc = d(model,V,T,@f(X_gc)))
     _d = zeros(eltype(_d_gc),length(z))
     _0 = zero(eltype(_d))
-    _zz = model.groups.n_groups_cache
+    _zz = model.params.mixed_segment.values
     for i ∈ @comps
         _z = _zz[i]
         ∑zinv2 = 1/(sum(_z)^2)
@@ -188,8 +186,8 @@ Optimizations for single component SAFTgammaMieModel
 #######
 
 function d_gc_av(model::SAFTgammaMieModel,V,T,z::SingleComp,_d_gc = d(model,V,T,@f(X_gc)))
-    _0 = zero(eltype(_d_gc))
-    _z = only(model.groups.n_groups_cache)  
+    _0 = zero(Base.promote_eltype(_d_gc,z))
+    _z = only(model.params.mixed_segment.values)  
     ∑zinv2 = 1/(sum(_z)^2)
     di = _0
     for k ∈ @groups

--- a/src/models/SAFT/SAFTgammaMie/variants/structSAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/variants/structSAFTgammaMie.jl
@@ -82,7 +82,7 @@ function structSAFTgammaMie(components;
     
     mixed_segment = MixedGCSegmentParam(groups,shapefactor.values,gc_segment.values)
     
-    segment = SingleParam("segment",components,group_sum(groups,nothing))
+    segment = SingleParam("segment",components,group_sum(mixed_segment,nothing))
     
     gc_sigma = sigma_LorentzBerthelot(params["sigma"])  
     gc_sigma.values .*= 1E-10

--- a/src/models/SAFT/SAFTgammaMie/variants/structSAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/variants/structSAFTgammaMie.jl
@@ -45,6 +45,7 @@ end
 - `epsilon`: Pair Parameter (`Float64`) - Mixed reduced dispersion energy`[K]`
 - `epsilon_assoc`: Association Parameter (`Float64`) - Reduced association energy `[K]`
 - `bondvol`: Association Parameter (`Float64`) - Association Volume
+- `mixed_segment`: Mixed Group Contribution Parameter: ∑nᵢₖνₖmₖ
 
 ## Input models
 - `idealmodel`: Ideal Model

--- a/src/models/cubic/mixing/PPR78.jl
+++ b/src/models/cubic/mixing/PPR78.jl
@@ -71,7 +71,7 @@ function mixing_rule(model::CubicModel,V,T,z,mixing_model::PPR78Rule,α,a,b,c)
     B = mixing_model.params.B.values
     groups = mixing_model.groups 
     gc = 1:length(groups.flattenedgroups)
-    z̄n = groups.n_groups_cache
+    z̄n = groups.n_flattenedgroups
    
     for i ∈ @comps
         zni = z̄n[i]

--- a/src/modules/solvers/ad.jl
+++ b/src/modules/solvers/ad.jl
@@ -235,7 +235,10 @@ primalval(x::ForwardDiff.Dual) = primalval(ForwardDiff.value(x))
 @generated function primalval_struct(x::M) where M
     names = fieldnames(M)
     Base.typename(M).wrapper
-    primalvals = Expr(:call,Base.typename(M).wrapper,map(name -> :(primalval(x.$name)) ,names)...)
+    primalvals = Expr(:call,Base.typename(M).wrapper)
+    for name in names
+        push!(primalvals.args,:(primalval(x.$name)))
+    end
     return primalvals
 end
 

--- a/src/utils/recombine.jl
+++ b/src/utils/recombine.jl
@@ -26,3 +26,57 @@ end
 function recombine_impl!(model::EoSModel)
     return model
 end
+
+function promote_model(::Type{T},model::EoSModel) where T <: Number
+    return promote_model_struct(T,model)
+end
+
+@generated function promote_model_struct(::Type{T},model::M) where {T,M}
+    names = fieldnames(M)
+    Base.typename(M).wrapper
+    expr = Expr(:call,Base.typename(M).wrapper)
+    M̄ = parameterless_type(M)
+    for name in names
+        if isconcretetype(fieldtype(M̄,name))
+            push!(expr.args,:(deepcopy(model.$name))) #TODO: this should only copy in some particular cases.
+        else
+            push!(expr.args,:(promote_model($T,model.$name)))
+        end
+    end
+    return expr
+end
+
+function promote_model(::Type{T},param::SingleParam) where T
+    values = Vector{T}(param.values)
+    return SingleParam{T}(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
+end
+
+function promote_model(::Type{T},param::PairParam) where T
+    values = Matrix{T}(param.values)
+    return PairParam{T}(param.name,param.components,values,param.ismissingvalues,param.sourcecsvs,param.sources)
+end
+
+function promote_model(::Type{T},param::AssocParam) where T
+    v = param.values
+    vals = Vector{T}(v.values)
+    values = Compressed4DMatrix(vals,v.outer_indices,v.inner_indices,v.outer_size,v.inner_size)
+    return AssocParam{T}(param.name,param.components,values,param.sites,param.sourcecsvs,param.sources)
+end
+
+function promote_model(::Type{T},param::MixedGCSegmentParam) where T
+    vals = param.values
+    p,v = vals.p,vals.v
+    v2 = Vector{T}(v)
+    values = PackedVofV(p,v2)
+    return MixedGCSegmentParam{T}(param.name,param.components,values)
+end
+promote_model(::Type{T},v::AbstractArray{<:AbstractString}) where T = v
+
+promote_model(::Type{T},params::EoSParam) where T = promote_model_struct(T,params)
+promote_model(::Type{T},param::ClapeyronParam) where T = deepcopy(param)
+promote_model(::Type{T},param::AssocOptions) where T = param
+promote_model(::Type{T},param::ReferenceState) where T = param
+promote_model(::Type{T},param::SpecialComp) where T = param
+promote_model(::Type{T},param::GroupParam) where T = param
+promote_model(::Type{T},param::SiteParam) where T = param
+

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -187,9 +187,9 @@ end
 
 function each_split_model(param::GroupParam,__group,Ic,Ig)
     grouptype = param.grouptype
-    components = param.components[I]
-    groups = param.groups[I]
-    n_groups = param.n_groups[I]
+    components = param.components[Ic]
+    groups = param.groups[Ic]
+    n_groups = param.n_groups[Ic]
     sourcecsvs = param.sourcecsvs
     len_groups = length(param.flattenedgroups)
 
@@ -230,7 +230,20 @@ function each_split_model(param::MixedGCSegmentParam{T},group,Ic,Ig) where T
 
     src = param.values
     ng = length(group.flattenedgroups)
-    dest  = PackedVectorsOfVectors.packed_fill(0.0,FillArrays.fill(ng,length(Ic)))
+    
+    #count unique groups
+    ncount = zeros(T,ng)
+    for k in Ig
+        ncount[k] = 1
+    end
+    ngg = count(!iszero,ncount)
+    ncc = length(Ic)
+    
+    #reuse vector
+    resize!(ncount,ngg*ncc)
+    p = zeros(Int64,length(Ic)+1)
+    p .= 1:ngg:(ncc*ngg + 1)
+    dest = PackedVofV(p,ncount)
     
     for (k,i) in pairs(Ic)
         pii = src[i]


### PR DESCRIPTION
SAFT gamma Mie now supports parametric number types:
```
julia> model = SAFTgammaMie(["water","acetone"])
SAFTgammaMie{BasicIdeal, Float64} with 2 components:
 "water": "H2O" => 1
 "acetone": "CH3COCH3" => 1
Group Type: SAFTgammaMie
Contains parameters: segment, shapefactor, lambda_a, lambda_r, sigma, epsilon, epsilon_assoc, bondvol, mixed_segment
```
some additional changes:
- `SAFTgammaMieParam` now has a `mixed_segment::MixedSegmentGCParam` (a new parameter type), this replaces the use of n_groups_cache, as GroupParam is not the correct Clapeyron parameter type to be parametrized by number type.
- apart from `SAFTgammaMie`, `StructSAFTgammaMie`, `PCPSAFT` (and group variants), `pharmaPCSAFT`, group PCSAFTs, and `CPPCSAFT` also support parametrization by number type
-  a new utility, `promote_model(::Type{T},model)` that changes the number type of an specific EoS model (if its possible)
- support for implicit AD in `crit_pure`