### PR TITLE
Simplify bubble/dew routines

### DIFF
--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -238,7 +238,9 @@ function improve_bubbledew_suggestion(model,p0,T0,x,y,method,in_media,high_condi
     ϕl = K = similar(μl)
     ϕl .= exp.(μl ./ RT) ./ Zl
     ϕv = virial_phi(model,p,T,y) #virial fugacity coefficient, skips volume calculation
-    K .= ϕl ./ ϕv
+    if all(!isnan,@view(ϕv[in_media]))
+        K .= ϕl ./ ϕv
+    end
     K_r = @view K[in_media]
     if FugEnum.is_bubble(method)
         x_r = @view x[in_media]
@@ -258,10 +260,11 @@ function improve_bubbledew_suggestion(model,p0,T0,x,y,method,in_media,high_condi
     end
 end
 
+_virial(model,V,T,z) = second_virial_coefficient(model,T,z)
+
 function virial_phi(model,p,T,z)
-    B(model,v,T,z) = second_virial_coefficient(model,T,z)
     pRT = p/(Rgas(model)*T)
-    dB = VT_molar_gradient(model,zero(p),T,z,B)
+    dB = VT_molar_gradient(model,zero(p),T,z,_virial)
     return exp.(dB .* pRT)
 end
 

--- a/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
@@ -83,22 +83,6 @@ function bubble_pressure_impl(model::EoSModel, T, x,method::ChemPotBubblePressur
     else
         model_y = nothing
     end
-
-    Ts = isnothing(model_y) ? T_scales(model) : T_scales(model_y)
-
-    if T > 0.9minimum(Ts) && method.ss
-        converged,res = _fug_OF_ss(model,model_y,p0,T,x,y0,(vl,vv),true,true,volatiles)
-        p,T,x,y,vol,lnK = res
-        volx,voly = vol
-        if converged
-            return p,volx,voly,index_expansion(y,volatiles)
-        elseif isnan(volx) || isnan(voly)
-            return p,volx,voly,index_expansion(y,volatiles)
-        else
-            y0 = y
-            vl,vv = vol
-        end
-    end
     ηl = η_from_v(model, vl, T, x)
     ηv = η_from_v(model, model_y, vv, T, y0)
     _,idx_max = findmax(y0)
@@ -214,21 +198,6 @@ function bubble_temperature_impl(model::EoSModel,p,x,method::ChemPotBubbleTemper
         y0 = y0[volatiles]
     else
         model_y = nothing
-    end
-    Ps = isnothing(model_y) ? p_scale(model,y0) : p_scale(model_y,y0)
-    if log(p) > 0.9log(Ps) && method.ss
-        converged,res = _fug_OF_ss(model,model_y,p,T0,x,y0,(vl,vv),true,false,volatiles)
-        p,T,x,y,vol,lnK = res
-        volx,voly = vol
-        if converged
-            return T,volx,voly,index_expansion(y,volatiles)
-        elseif isnan(volx) || isnan(voly)
-            return T,volx,voly,index_expansion(y,volatiles)
-        else
-            y0 = y
-            vl,vv = vol
-            T0 = T
-        end
     end
     ηl = η_from_v(model, vl, T0, x)
     ηv = η_from_v(model, model_y, vv, T0, y0)

--- a/src/methods/property_solvers/multicomponent/bubble_point/bubble_fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point/bubble_fugacity.jl
@@ -19,11 +19,11 @@ Returns: NLSolvers.NEqProblem
 function OF_bubblepy! end
 
 function OF_bubblepy!(model, x, T, vol_cache)
-    return _fug_OF_neqsystem(model,x, nothing, nothing, T, vol_cache,true,true,(:liquid,:vapor))
+    return _fug_OF_neqsystem(model,x, nothing, nothing, T, vol_cache,FugEnum.BUBBLE_PRESSURE,(:liquid,:vapor))
 end
 
 function OF_bubblepy!(model,modely, x, T, vol_cache,volatile)
-    return _fug_OF_neqsystem(model, modely, x, nothing, nothing, T, vol_cache, true, true, (:liquid,:vapor), volatile)
+    return _fug_OF_neqsystem(model, modely, x, nothing, nothing, T, vol_cache, FugEnum.BUBBLE_PRESSURE, (:liquid,:vapor), volatile)
 end
 
 """
@@ -77,7 +77,7 @@ function bubble_pressure_fug(model::EoSModel, T, x, y0, p0; vol0=(nothing,nothin
         model_y = nothing
     end
 
-    converged,res = _fug_OF_ss(model,model_y,p0,T,x,y0,vol0,true,true,volatiles;itmax_ss = itmax_ss, itmax_newton = itmax_newton,tol_pT = tol_p,tol_xy = tol_y,tol_of=tol_of)
+    converged,res = _fug_OF_ss(model,model_y,p0,T,x,y0,vol0,FugEnum.BUBBLE_PRESSURE,volatiles;itmax_ss = itmax_ss, itmax_newton = itmax_newton,tol_pT = tol_p,tol_xy = tol_y,tol_of=tol_of)
     p,T,x,y,vol,lnK = res
     volx,voly = vol
     if converged
@@ -226,11 +226,11 @@ Returns: NLSolvers.NEqProblem
 function OF_bubbleTy! end
 
 function OF_bubbleTy!(model, x, p, vol_cache)
-    return _fug_OF_neqsystem(model,x, nothing, p, nothing, vol_cache, true, false, (:liquid,:vapor))
+    return _fug_OF_neqsystem(model,x, nothing, p, nothing, vol_cache, FugEnum.BUBBLE_TEMPERATURE, (:liquid,:vapor))
 end
 
 function OF_bubbleTy!(model,modely, x, p, vol_cache,volatile)
-    return _fug_OF_neqsystem(model, modely, x, nothing, p, nothing, vol_cache, true, false, (:liquid,:vapor), volatile)
+    return _fug_OF_neqsystem(model, modely, x, nothing, p, nothing, vol_cache, FugEnum.BUBBLE_TEMPERATURE, (:liquid,:vapor), volatile)
 end
 
 """
@@ -284,7 +284,7 @@ function bubble_temperature_fug(model::EoSModel, p, x, y0, T0; vol0=(nothing,not
         model_y = nothing
     end
 
-    converged,res = _fug_OF_ss(model,model_y,p,T0,x,y0,vol0,true,false,volatiles;itmax_ss = itmax_ss, itmax_newton = itmax_newton, tol_pT = tol_T, tol_xy = tol_y, tol_of = tol_of)
+    converged,res = _fug_OF_ss(model,model_y,p,T0,x,y0,vol0,FugEnum.BUBBLE_TEMPERATURE,volatiles;itmax_ss = itmax_ss, itmax_newton = itmax_newton, tol_pT = tol_T, tol_xy = tol_y, tol_of = tol_of)
     p,T,x,y,vol,lnK = res
     volx,voly = vol
     if converged

--- a/src/methods/property_solvers/multicomponent/bubble_point/bubble_fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point/bubble_fugacity.jl
@@ -19,7 +19,7 @@ Returns: NLSolvers.NEqProblem
 function OF_bubblepy! end
 
 function OF_bubblepy!(model, x, T, vol_cache)
-    return _fug_OF_neqsystem(model,x, nothing, nothing, T, vol_cache,FugEnum.BUBBLE_PRESSURE,(:liquid,:vapor))
+    return _fug_OF_neqsystem(model,x, nothing, nothing, T, vol_cache, FugEnum.BUBBLE_PRESSURE,(:liquid,:vapor))
 end
 
 function OF_bubblepy!(model,modely, x, T, vol_cache,volatile)

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -28,15 +28,15 @@ function __x0_dew_pressure(model::EoSModel,T,y,x0=nothing,condensables = FillArr
     p0inv_r = 1. ./ first.(sat)
     p0inv = index_expansion(p0inv_r,condensables)
     yipi = y .* p0inv
-    p = 1/sum(yipi)
+    p0 = 1/sum(yipi)
     if isnothing(x0)
         xx = yipi
-        xx .*= p
+        xx .*= p0
     else
         xx = x0
     end
     high_conditions = __is_high_pressure_state(pure,sat,T)
-    p,_,x,_,vl0,vv0 = improve_bubbledew_suggestion(model,p,T0,xx,y,FugEnum.DEW_PRESSURE,condensables,high_conditions)
+    p,_,x,_,vl0,vv0 = improve_bubbledew_suggestion(model,p0,T,xx,y,FugEnum.DEW_PRESSURE,condensables,high_conditions)
     return p,vl0,vv0,x
 end
 

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -182,7 +182,7 @@ function antoine_dew_solve(dpdt,p_dew,y)
     end
     Tmin,Tmax = extrema(x -> 1/last(x),dpdt)
     prob = Roots.ZeroProblem(antoine_f0,(Tmin,Tmax))
-
+    return Roots.solve(prob)
 end
 
 function x0_dew_temperature(model::EoSModel,p,y,T0 = nothing)

--- a/src/methods/property_solvers/multicomponent/dew_point/dew_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point/dew_chempot.jl
@@ -82,23 +82,6 @@ function dew_pressure_impl(model::EoSModel, T, y,method::ChemPotDewPressure)
     else
         model_x = nothing
     end
-
-    Ts = isnothing(model_x) ? T_scales(model) : T_scales(model_x)
-
-    if T > 0.9minimum(Ts) && method.ss
-        converged,res = _fug_OF_ss(model_x,model,p0,T,x0,y,(vl,vv),false,true,condensables)
-        p,T,x,y,vol,lnK = res
-        volx,voly = vol
-        if converged
-            return p,volx,voly,index_expansion(x,condensables)
-        elseif isnan(volx) || isnan(voly)
-            return p,volx,voly,index_expansion(x,condensables)
-        else
-            x0 = x
-            vl,vv = vol
-            T0 = T
-        end
-    end
     ηl0 = η_from_v(model,model_x,vl,T,x0)
     ηv0 = η_from_v(model,vv,T,y)
     _,idx_max = findmax(x0)
@@ -207,20 +190,7 @@ function dew_temperature_impl(model::EoSModel,p,y,method::ChemPotDewTemperature)
     else
         model_x = nothing
     end
-    Ps = isnothing(model_x) ? p_scale(model,x0) : p_scale(model_x,x0)
-    if log(p) > 0.9log(Ps) && method.ss
-        converged,res = _fug_OF_ss(model_x,model,p,T0,x0,y,(vl,vv),false,false,condensables)
-        p,T,x,y,vol,lnK = res
-        volx,voly = vol
-        if converged
-            return T,volx,voly,index_expansion(x,condensables)
-        elseif isnan(volx) || isnan(voly)
-            return T,volx,voly,index_expansion(x,condensables)
-        else
-            x0 = x
-            vl,vv = vol
-        end
-    end
+
     ηl = η_from_v(model,model_x,vl,T0,x0)
     ηv = η_from_v(model,vv,T0,y)
     _,idx_max = findmax(x0)

--- a/src/methods/property_solvers/multicomponent/dew_point/dew_fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point/dew_fugacity.jl
@@ -20,11 +20,11 @@ Returns: NLSolvers.NEqProblem
 function OF_dewPx! end
 
 function OF_dewPx!(model, y, T, vol_cache)
-    return _fug_OF_neqsystem(model, nothing, y, nothing, T, vol_cache, false, true, (:liquid,:vapor))
+    return _fug_OF_neqsystem(model, nothing, y, nothing, T, vol_cache, FugEnum.DEW_PRESSURE, (:liquid,:vapor))
 end
 
 function OF_dewPx!(modelx,modely, y, T, vol_cache,condensable)
-    return _fug_OF_neqsystem(modelx, modely, nothing, y, nothing, T, vol_cache, false, true, (:liquid,:vapor), condensable)
+    return _fug_OF_neqsystem(modelx, modely, nothing, y, nothing, T, vol_cache, FugEnum.DEW_PRESSURE, (:liquid,:vapor), condensable)
 end
 
 """
@@ -77,7 +77,7 @@ function dew_pressure_fug(model::EoSModel, T, y, x0, p0; vol0=(nothing,nothing),
         model_x = nothing
     end
 
-    converged,res = _fug_OF_ss(model_x,model,p0,T,x0,y,vol0,false,true,condensables;itmax_ss = itmax_ss, itmax_newton = itmax_newton,tol_pT = tol_p, tol_xy = tol_x, tol_of = tol_of)
+    converged,res = _fug_OF_ss(model_x,model,p0,T,x0,y,vol0,FugEnum.DEW_PRESSURE,condensables;itmax_ss = itmax_ss, itmax_newton = itmax_newton,tol_pT = tol_p, tol_xy = tol_x, tol_of = tol_of)
     p,T,x,y,vol,lnK = res
     volx,voly = vol
     if converged
@@ -226,11 +226,11 @@ Returns: NLSolvers.NEqProblem
 function OF_dewTx! end
 
 function OF_dewTx!(model, y, p, vol_cache)
-    return _fug_OF_neqsystem(model, nothing, y, p, nothing, vol_cache, false, false, (:liquid,:vapor))
+    return _fug_OF_neqsystem(model, nothing, y, p, nothing, vol_cache, FugEnum.DEW_TEMPERATURE, (:liquid,:vapor))
 end
 
 function OF_dewTx!(model,modely, y, p, vol_cache,condensable)
-    return _fug_OF_neqsystem(model, modely, nothing, y, p, nothing, vol_cache, false, false, (:liquid,:vapor), condensable)
+    return _fug_OF_neqsystem(model, modely, nothing, y, p, nothing, vol_cache, FugEnum.DEW_TEMPERATURE, (:liquid,:vapor), condensable)
 end
 
 """
@@ -282,7 +282,7 @@ function dew_temperature_fug(model::EoSModel, p, y, x0, T0; vol0=(nothing,nothin
         model_x = nothing
     end
 
-    converged,res = _fug_OF_ss(model_x,model,p,T0,x0,y,vol0,false,false,condensables;itmax_ss = itmax_ss, itmax_newton = itmax_newton, tol_pT = tol_T, tol_xy = tol_x, tol_of = tol_of)
+    converged,res = _fug_OF_ss(model_x,model,p,T0,x0,y,vol0,FugEnum.DEW_TEMPERATURE,condensables;itmax_ss = itmax_ss, itmax_newton = itmax_newton, tol_pT = tol_T, tol_xy = tol_x, tol_of = tol_of)
     p,T,x,y,vol,lnK = res
     volx,voly = vol
     if converged

--- a/src/methods/property_solvers/multicomponent/flash/QP.jl
+++ b/src/methods/property_solvers/multicomponent/flash/QP.jl
@@ -28,11 +28,11 @@ function qp_flash_x0(model,β,p,z,method::FlashMethod)
         else
 
         pures = split_model(model)
-        dpdT = extended_dpdT_temperature.(pure,p)
+        dpdT = extended_dpdT_temperature.(pures,p)
         Tmax = antoine_dew_solve(dpdT,p,z)
         Tmin = antoine_bubble_solve(dpdT,p,z)
         #@show Td0,Tb0
-        T0 = 1 ./ last.(sat)
+        T0 = 1 ./ last.(dpdT)
         #Tmin,Tmax = extrema(T0)
         #we approximate sat(T) ≈ exp(-dpdT*T*T(1/T - 1/T0)/p)*p
         K = similar(T0)

--- a/src/methods/property_solvers/multicomponent/flash/QP.jl
+++ b/src/methods/property_solvers/multicomponent/flash/QP.jl
@@ -28,16 +28,11 @@ function qp_flash_x0(model,β,p,z,method::FlashMethod)
         else
 
         pures = split_model(model)
-        sat = extended_saturation_temperature.(pures,p)
-        _crit = __crit_pure.(sat,pures)
-        fix_sat_ti!(sat,pures,_crit,p)
-        dpdT = __dlnPdTinvsat.(pures,sat,_crit,p)
-        dew_prob = antoine_dew_problem(dpdT,p,z)
-        Tmax = Roots.solve(dew_prob)
-        bubble_prob = antoine_bubble_problem(dpdT,p,z)
-        Tmin = Roots.solve(bubble_prob)
+        dpdT = extended_dpdT_temperature.(pure,p)
+        Tmax = antoine_dew_solve(dpdT,p,z)
+        Tmin = antoine_bubble_solve(dpdT,p,z)
         #@show Td0,Tb0
-        T0 = first.(sat)
+        T0 = 1 ./ last.(sat)
         #Tmin,Tmax = extrema(T0)
         #we approximate sat(T) ≈ exp(-dpdT*T*T(1/T - 1/T0)/p)*p
         K = similar(T0)

--- a/src/methods/property_solvers/multicomponent/fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/fugacity.jl
@@ -1,8 +1,16 @@
 ##general successive substitution method to solve bubble/dew problems via fugacity coefficients
+module FugEnum
+    @enum BubbleDew BUBBLE_PRESSURE,BUBBLE_TEMPERATURE,DEW_PRESSURE,DEW_TEMPERATURE
+    is_bubble(x::BubbleDew) = (x == BUBBLE_PRESSURE || x == BUBBLE_TEMPERATURE)
+    is_dew(x::BubbleDew) = !is_bubble(x)
+    is_temperature(x::BubbleDew) = (x == BUBBLE_TEMPERATURE  || x == DEW_TEMPERATURE)
+    is_pressure(x::BubbleDew) = !is_temperature(x) 
+end
 
-function _fug_OF_ss(model::EoSModel,p,T,x,y,vol0,_bubble,_pressure;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
+function _fug_OF_ss(model::EoSModel,p,T,x,y,vol0,method;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
     volx,voly = vol0
     converged = false
+    _bubble,_pressure = FugEnum.is_bubble(method),FugEnum.is_pressure(method)
     tol_stability = abs2(cbrt(tol_xy))
     #caches for ∂lnϕ∂n∂P∂T/∂lnϕ∂n∂P
     if _pressure
@@ -141,21 +149,22 @@ function _fug_OF_ss(model::EoSModel,p,T,x,y,vol0,_bubble,_pressure;itmax_ss = 5,
     return converged,(p,T,_x,_y,(volx,voly),lnK)
 end
 
-function _fug_OF_ss(modelx::EoSModel,modely::Nothing,p,T,x,y,vol0,_bubble,_pressure,_view;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
-    return _fug_OF_ss(modelx,p,T,x,y,vol0,_bubble,_pressure;itmax_ss, itmax_newton,tol_pT,tol_xy,tol_of)
+function _fug_OF_ss(modelx::EoSModel,modely::Nothing,p,T,x,y,vol0,method,_view;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
+    return _fug_OF_ss(modelx,p,T,x,y,vol0,method;itmax_ss, itmax_newton,tol_pT,tol_xy,tol_of)
 end
 
-function _fug_OF_ss(modelx::Nothing,modely::EoSModel,p,T,x,y,vol0,_bubble,_pressure,_view;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
-    return _fug_OF_ss(modely,p,T,x,y,vol0,_bubble,_pressure;itmax_ss, itmax_newton,tol_pT,tol_xy,tol_of)
+function _fug_OF_ss(modelx::Nothing,modely::EoSModel,p,T,x,y,vol0,method,_view;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
+    return _fug_OF_ss(modely,p,T,x,y,vol0,method;itmax_ss, itmax_newton,tol_pT,tol_xy,tol_of)
 end
 
 
 ##general successive substitution method to solve bubble/dew problems via fugacity coefficients
 ##support for nonvolatiles/noncondensables
 
-function _fug_OF_ss(modelx::EoSModel,modely::EoSModel,p,T,x,y,vol0,_bubble,_pressure,_view;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
+function _fug_OF_ss(modelx::EoSModel,modely::EoSModel,p,T,x,y,vol0,method,_view;itmax_ss = 5, itmax_newton = 10,tol_pT = 1e-8,tol_xy = 1e-8,tol_of = 1e-8)
     volx,voly = vol0
     converged = false
+    _bubble,_pressure = FugEnum.is_bubble(method),FugEnum.is_pressure(method)
     tol_stability = abs2(cbrt(tol_xy))
     if _bubble
         n = length(modely)
@@ -375,7 +384,10 @@ function _fug_J(J,x,y,∂lnϕ∂nx,∂lnϕ∂ny,_bubble)
     return J
 end
 
-function _fug_OF_neqsystem(model,_x, _y, _p, _T, vol_cache,_bubble,_pressure,_phase)
+function _fug_OF_neqsystem(model,_x, _y, _p, _T, vol_cache,method,_phase)
+    
+    _bubble,_pressure = FugEnum.is_bubble(method),FugEnum.is_pressure(method)
+ 
     #caches for ∂lnϕ∂n∂P∂T/∂lnϕ∂n∂P
 
     XX = something(_p,_T)
@@ -458,12 +470,12 @@ end
 ##support for noncondensables/nonvolatiles
 
 #dispatch to simplified function
-function _fug_OF_neqsystem(modelx::EoSModel,modely::Nothing,_x, _y, _p, _T, vol_cache,_bubble,_pressure,_phase,_view)
-    return  _fug_OF_neqsystem(modelx,_x, _y, _p, _T, vol_cache,_bubble,_pressure,_phase)
+function _fug_OF_neqsystem(modelx::EoSModel,modely::Nothing,_x, _y, _p, _T, vol_cache,method,_phase,_view)
+    return  _fug_OF_neqsystem(modelx,_x, _y, _p, _T, vol_cache,method,_phase)
 end
 
-function _fug_OF_neqsystem(modelx::Nothing,modely::EoSModel,_x, _y, _p, _T, vol_cache,_bubble,_pressure,_phase,_view)
-    return  _fug_OF_neqsystem(modely,_x, _y, _p, _T, vol_cache,_bubble,_pressure,_phase)
+function _fug_OF_neqsystem(modelx::Nothing,modely::EoSModel,_x, _y, _p, _T, vol_cache,method,_phase,_view)
+    return  _fug_OF_neqsystem(modely,_x, _y, _p, _T, vol_cache,method,_phase)
 end
 
 
@@ -481,7 +493,8 @@ function _select_xy(w,K,x,y,_bubble,_view)
 end
 
 #main function
-function _fug_OF_neqsystem(modelx::EoSModel,modely::EoSModel,_x, _y, _p, _T, vol_cache,_bubble,_pressure,_phase,_view)
+function _fug_OF_neqsystem(modelx::EoSModel,modely::EoSModel,_x, _y, _p, _T, vol_cache,method,_phase,_view)
+    _bubble,_pressure = FugEnum.is_bubble(method),FugEnum.is_pressure(method)
     if _bubble
         w = similar(_y)
         wx = x

--- a/src/methods/property_solvers/multicomponent/fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/fugacity.jl
@@ -498,26 +498,26 @@ function _select_xy(w,K,x,y,_bubble,_view)
 end
 
 #main function
-function _fug_OF_neqsystem(modelx::EoSModel,modely::EoSModel,_x, _y, _p, _T, vol_cache,method,_phase,_view)
+function _fug_OF_neqsystem(modelx::EoSModel,modely::EoSModel, _x, _y, _p, _T, vol_cache,method,_phase,_view)
     _bubble,_pressure = FugEnum.is_bubble(method),FugEnum.is_pressure(method)
     if _bubble
-        w = similar(_y)
-        wx = x
+        w = similar(@view(_x[_view]))
+        wx = _x
         wy = w
     else
-        w = similar(_x)
+        w = similar(@view(_y[_view]))
         wx = w
-        wy = y
+        wy = _y
     end
 
     K = similar(w)
     XX = something(_p,_T)
     if _pressure
-        Hϕx = ∂lnϕ_cache(model, XX, XX, wx, Val{false}())
-        Hϕy = ∂lnϕ_cache(model, XX, XX, wy, Val{false}())
+        Hϕx = ∂lnϕ_cache(modelx, XX, XX, wx, Val{false}())
+        Hϕy = ∂lnϕ_cache(modely, XX, XX, wy, Val{false}())
     else
-        Hϕx = ∂lnϕ_cache(model, XX, XX, wx, Val{true}())
-        Hϕy = ∂lnϕ_cache(model, XX, XX, wy, Val{true}())
+        Hϕx = ∂lnϕ_cache(modelx, XX, XX, wx, Val{true}())
+        Hϕy = ∂lnϕ_cache(modely, XX, XX, wy, Val{true}())
     end
 
     function f!(F, inc)

--- a/src/methods/property_solvers/multicomponent/fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/fugacity.jl
@@ -1,6 +1,11 @@
 ##general successive substitution method to solve bubble/dew problems via fugacity coefficients
 module FugEnum
-    @enum BubbleDew BUBBLE_PRESSURE,BUBBLE_TEMPERATURE,DEW_PRESSURE,DEW_TEMPERATURE
+    @enum BubbleDew begin
+        BUBBLE_PRESSURE
+        BUBBLE_TEMPERATURE
+        DEW_PRESSURE
+        DEW_TEMPERATURE
+    end
     is_bubble(x::BubbleDew) = (x == BUBBLE_PRESSURE || x == BUBBLE_TEMPERATURE)
     is_dew(x::BubbleDew) = !is_bubble(x)
     is_temperature(x::BubbleDew) = (x == BUBBLE_TEMPERATURE  || x == DEW_TEMPERATURE)

--- a/src/methods/property_solvers/singlecomponent/singlecomponent.jl
+++ b/src/methods/property_solvers/singlecomponent/singlecomponent.jl
@@ -40,6 +40,11 @@ function μp_equality1_p(model1,model2,v1,v2,T,ps,μs)
     return SVector(Fμ,Fp)
 end
 
+function μp_equality1_p(model,v1,v2,T) 
+    ps,μs = equilibria_scale(model)
+    μp_equality1_p(model,model,v1,v2,T,ps,μs)
+end
+
 function μp_equality1_T(model1,model2,v1,v2,p,T,ps,μs)
     z = SA[1.0]
     RT = Rgas(model1)*T

--- a/src/methods/property_solvers/spinodal.jl
+++ b/src/methods/property_solvers/spinodal.jl
@@ -186,4 +186,13 @@ function Obj_crit_pure_sp(xx,model,p,z,ps,lb_v)
     return SVector((pᵢ-p)/ps,dpdVᵢ/(ps*lb_v))
 end
 
+function eigmin_minimum_pressure(model,T,z,v0hi,v0lo = -second_virial_coefficient(model,T,z))
+    f0(v) = diffusive_eigvalue(model,exp(v),T,z)
+    ln_vhi = log(v0hi)
+    ln_vlo = log(v0lo)
+    ln_v = Solvers.optimize(f0,(ln_vhi,ln_vlo),Solvers.BoundOptim1Var())
+    v = exp(ln_v)
+    return pressure(model,v,T,z),v,f0(ln_v)
+end
+
 export spinodal_pressure, spinodal_temperature

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -57,6 +57,20 @@ function VT_diffusive_stability(model,V,T,z = SA[1.0])
     λ = eigmin(Hermitian(HΨ)) # calculating just minimum eigenvalue more efficient than calculating all & finding min
     return λ > 0
 end
+
+function VT_diffusive_eigvalue(model,V,T,z = SA[1.0])
+    ρᵢ = similar(z,Base.promote_eltype(V,z))
+    ρᵢ .= z ./ V
+    HΨ = Ψ_hessian(model,T,ρᵢ)
+    if any(!isfinite,HΨ)
+        return zero(eltype(HΨ))/zero(eltype(HΨ))
+    end
+    if length(model) == 1
+        return HΨ[1,1]
+    end
+    return eigmin(Hermitian(HΨ)) # calculating just minimum eigenvalue more efficient than calculating all & finding min
+end
+
 """
     diffusive_stability(model,p,T,z = SA[1.0],phase = :unknown,threaded = true,vol0 = nothing)
 

--- a/src/models/Electrolytes/Ion/DH.jl
+++ b/src/models/Electrolytes/Ion/DH.jl
@@ -80,21 +80,23 @@ function a_ion(model::DHModel, V, T, z,_data=@f(data))
     ϵ_r, σ = _data
     Z = model.params.charge.values
     ∑z = sum(z)
-    ρ = N_A*sum(z)/V
     s = e_c^2/(4π*ϵ_0*ϵ_r*k_B*T)
-    κ = sqrt(4π*s*ρ/∑z)*sqrt(sum(z[i]*Z[i]*Z[i] for i ∈ model.icomponents))
-    iszero(κ) && return zero(κ)
+    I = sum(z[i]*Z[i]*Z[i] for i ∈ model.icomponents)
+    κ = Solvers.strong_zero(I) do ii
+        sqrt(4π*s*N_A/V)*sqrt(ii)
+    end
+    #κ = sqrt(4π*s*N_A/V)*sqrt(sum(z[i]*Z[i]*Z[i] for i ∈ model.icomponents))
+    #iszero(primalval(κ)) && return zero(κ)
     res = zero(Base.promote_eltype(model,V,T,z))
     for i in model.icomponents
         Zi = Z[i]
-        if Z[i] != 0
+        if Z[i] != 0 && !iszero(primalval(z[i]))
             yi = σ[i]*κ
             yip1 = yi + 1
-            χi = 3/(yi*yi*yi)*(3/2+log1p(yi)-2*yip1+1/2*yip1*yip1)
+            χi = 3/(yi*yi*yi)*(1.5 + log1p(yi) - 2*yip1 + 0.5*yip1*yip1)
             res +=z[i]*Zi*Zi*χi
         end
     end
-
     return -1/3*s*κ*res/∑z
     #y = σ*κ
     #χ = @. 3/y^3*(3/2+log1p(y)-2*(1+y)+1/2*(1+y)^2)

--- a/src/models/Electrolytes/Ion/DH.jl
+++ b/src/models/Electrolytes/Ion/DH.jl
@@ -82,7 +82,7 @@ function a_ion(model::DHModel, V, T, z,_data=@f(data))
     ∑z = sum(z)
     ρ = N_A*sum(z)/V
     s = e_c^2/(4π*ϵ_0*ϵ_r*k_B*T)
-    κ = sqrt(4π*s*ρ*sum(z[i]*Z[i]*Z[i] for i ∈ model.icomponents)/∑z)
+    κ = sqrt(4π*s*ρ/∑z)*sqrt(sum(z[i]*Z[i]*Z[i] for i ∈ model.icomponents))
     iszero(κ) && return zero(κ)
     res = zero(Base.promote_eltype(model,V,T,z))
     for i in model.icomponents

--- a/src/models/Electrolytes/Ion/MSA.jl
+++ b/src/models/Electrolytes/Ion/MSA.jl
@@ -102,12 +102,15 @@ function screening_length(model::MSAModel,V,T,z,ϵ_r = @f(data))
     ∑z = sum(z)
     ρ = N_A*sum(z)/V
     Δ = 1-π*ρ/6*sum(z[i]*σ[i]^3 for i ∈ @comps)/∑z
-
-    Γold = (4π*e_c^2/(4π*ϵ_0*ϵ_r*k_B*T)*ρ*sum(z[i]*Z[i]^2 for i ∈ iions)/∑z)^(1/2)
+    yyy = 4π*e_c^2/(4π*ϵ_0*ϵ_r*k_B*T)*ρ
+    
+    Γold = sqrt(4π*e_c^2/(4π*ϵ_0*ϵ_r*k_B*T)*ρ) * sqrt(sum(z[i]*Z[i]^2 for i ∈ iions)/∑z)
     _0 = zero(Γold)
+    iszero(Γold) && return _0
     Γnew = _0
     tol  = one(_0)
     iter = 1
+    k1 = sqrt(π*e_c^2*ρ/(4π*ϵ_0*ϵ_r*k_B*T))
     while tol>1e-12 && iter < 100
         Ω = 1+π*ρ/(2*Δ)*sum(z[i]*σ[i]^3/(1+Γold*σ[i]) for i ∈ iions)/∑z
         Pn = ρ/Ω*sum(z[i]*σ[i]*Z[i]/(1+Γold*σ[i]) for i ∈ iions)/∑z
@@ -117,10 +120,11 @@ function screening_length(model::MSAModel,V,T,z,ϵ_r = @f(data))
             Qi = (Z[i]-σ[i]^2*Pn*(π/(2Δ)))/(1+Γold*σ[i])
             ∑Q2x += z[i]*Qi^2
         end
-        Γnew = sqrt(π*e_c^2*ρ/(4π*ϵ_0*ϵ_r*k_B*T)*∑Q2x/∑z)
+        Γnew = k1*sqrt(∑Q2x/∑z)
         tol = abs(1-Γnew/Γold)
         Γold = Γnew
         iter += 1
     end
+
     return Γnew
 end

--- a/src/models/Electrolytes/base.jl
+++ b/src/models/Electrolytes/base.jl
@@ -91,6 +91,10 @@ function x0_volume_liquid(model::ESElectrolyteModel,p,T,z)
     return x0_volume_liquid(model.neutralmodel,p,T,z)*1.15
 end
 
+function x0_volume_gas(model::ESElectrolyteModel,p,T,z)
+    return x0_volume_gas(model.neutralmodel,p,T,z)
+end
+
 function mw(model::ElectrolyteModel)
     return mw(model.neutralmodel)
 end

--- a/src/modules/solvers/optimize.jl
+++ b/src/modules/solvers/optimize.jl
@@ -172,3 +172,61 @@ function only_fgh!(fgh!::T) where T
     fgh=fgh,
     h=h)
 end
+
+struct BoundOptim1Var end
+
+function optimize(f,x0::NTuple{2,T},method::BoundOptim1Var,options=OptimizationOptions()) where T<:Real
+    return _1var_optimize_quad(f,x0)
+end
+
+quad_interp(x,f) = quad_interp(x[1],x[2],x[3],f[1],f[2],f[3])
+
+function quad_interp(xa,xb,xc,fa,fb,fc)
+        #f1 = ax12 + bx1 + c
+    #f2 = ax22 + bx2 + c
+    #f3 = ax32 + bx3 + c
+    A = @SMatrix [xa*xa xa oneunit(xa); xb*xb xb oneunit(xb); xc*xc xc oneunit(xc)]
+    B = SVector((fa,fb,fc))
+    z = A\B
+    a,b,c = z
+    return a,b,c
+end
+
+function _1var_optimize_quad(f,x0)
+    xa,xb = minmax(x0[1],x0[2])
+    xa0,xb0 = xa,xb
+    fa,fb = f(xa),f(xb)
+    xc = 0.5*(xa + xb)
+    fc = f(xc)
+    for i in 1:20
+        a,b,c = quad_interp(xa,xb,xc,fa,fb,fc)
+        xmin = -b/(2*a)
+        fmin = f(xmin)
+        _f = SVector((fa,fb,fc,fmin))
+        f_worst,idx = findmax(_f)
+        if fmin != f_worst && isfinite(fmin)
+            _x = SVector((xa,xb,xc,xmin))
+            xa,xb,xc = StaticArrays.deleteat(_x,idx)
+            fa,fb,fc = StaticArrays.deleteat(_f,idx)
+        elseif fmin == f_worst
+            _f2 = SVector((fa,fb,fc))
+            _x2 = SVector((xa,xb,xc))
+            _,idx2 = findmax(_f2)
+            xa,xb = StaticArrays.deleteat(_x2,idx2)
+            fa,fb = StaticArrays.deleteat(_f2,idx2)
+            xc = 0.5*(xa + xb)
+            fc = f(xc)
+        else
+            return zero(fmin)/zero(fmin)
+        end
+        xmin,xmax = extrema((xa,xb,xc))
+        fxx = minimum((fa,fb,fc))
+        @show abs(xmin - xmax),fxx
+        if abs(xmin - xmax) < sqrt(eps(xmin))
+            break
+        end
+    end
+    xmin,xmax = extrema((xa,xb,xc))
+    @show xa0,xmin,xmax,xb0
+    return 0.5*(xmin + xmax)
+end

--- a/src/utils/split_model.jl
+++ b/src/utils/split_model.jl
@@ -402,6 +402,11 @@ function _split_model(param,splitter::AbstractVector{Int})
     end
 end
 
+function _split_model(param,bool_splitter::AbstractVector{Bool})
+    int_splitter = findall(bool_splitter)
+    return _split_model(param,int_splitter)
+end
+
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,5 +84,5 @@ include_distributed("test_methods_api.jl",2)
 include_distributed("test_methods_api_flash.jl",3)
 include_distributed("test_methods_electrolytes.jl",1)
 include_distributed("test_estimation.jl",1)
-include_distributed("test_issues.jl",4)
+include_distributed("test_issues.jl",1)
 

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -328,4 +328,31 @@
         bondvol=nothing))
         @test model1 isa CPA
     end
+
+    @testset "#357 - electrolyte equilibria" begin
+
+        model1 = ePCSAFT(["water"], ["calcium", "chloride"])
+        salts1 = [("calcium chloride", ("calcium" => 1, "chloride" => 2))]
+        x1 = molality_to_composition(model1, salts1, 1.0)
+        bub_test = 374.7581484748338
+        bubP1_test = 2971.744917038001
+
+        bubT1 = bubble_temperature(model1, 101325, x1, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"]))[1]
+        @test bubT1 ≈ bub_test rtol = 1e-6
+
+        bubT1_chempot = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(T0=373.0, nonvolatiles=["calcium","chloride"]))
+        @test_broken bubT1_chempot ≈ bub_test rtol = 1e-6
+        
+        bubT1_chempot2 = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(nonvolatiles=["calcium","chloride"]))
+        @test_broken bubT1_chempot2 ≈ bub_test rtol = 1e-6
+
+        bubT1_2 = bubble_temperature(model1, 101325, x, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"],y0=[1.,0.,0.],vol0=(1.8e-5,1.),T0=373.15))[1]
+        @test bubT1_2 ≈ bub_test rtol = 1e-6
+        
+        bubP1 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"],y0=[1.,0.,0.],vol0=(1e-5,1.)))
+        @test bubP1 ≈ bubP1_test rtol = 1e-6
+
+        bubP1_2 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"]))
+        @test bubP1 ≈ bubP1_test rtol = 1e-6
+    end
 end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -340,10 +340,10 @@
         bubT1 = bubble_temperature(model1, 101325, x1, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"]))[1]
         @test bubT1 ≈ bub_test rtol = 1e-6
 
-        bubT1_chempot = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(T0=373.0, nonvolatiles=["calcium","chloride"]))
+        bubT1_chempot = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(T0=373.0, nonvolatiles=["calcium","chloride"]))[1]
         @test_broken bubT1_chempot ≈ bub_test rtol = 1e-6
         
-        bubT1_chempot2 = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(nonvolatiles=["calcium","chloride"]))
+        bubT1_chempot2 = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(nonvolatiles=["calcium","chloride"]))[1]
         @test_broken bubT1_chempot2 ≈ bub_test rtol = 1e-6
 
         bubT1_2 = bubble_temperature(model1, 101325, x, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"],y0=[1.,0.,0.],vol0=(1.8e-5,1.),T0=373.15))[1]

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -349,10 +349,10 @@
         bubT1_2 = bubble_temperature(model1, 101325, x1, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"],y0=[1.,0.,0.],vol0=(1.8e-5,1.),T0=373.15))[1]
         @test bubT1_2 ≈ bub_test rtol = 1e-6
 
-        bubP1 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"],y0=[1.,0.,0.],vol0=(1e-5,1.)))
+        bubP1 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"],y0=[1.,0.,0.],vol0=(1e-5,1.)))[1]
         @test bubP1 ≈ bubP1_test rtol = 1e-6
 
-        bubP1_2 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"]))
+        bubP1_2 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"]))[1]
         @test bubP1 ≈ bubP1_test rtol = 1e-6
     end
 end

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -340,13 +340,13 @@
         bubT1 = bubble_temperature(model1, 101325, x1, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"]))[1]
         @test bubT1 ≈ bub_test rtol = 1e-6
 
-        bubT1_chempot = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(T0=373.0, nonvolatiles=["calcium","chloride"]))[1]
+        bubT1_chempot = bubble_temperature(model1, 101325, x1, ChemPotBubbleTemperature(T0=373.0, nonvolatiles=["calcium","chloride"]))[1]
         @test_broken bubT1_chempot ≈ bub_test rtol = 1e-6
 
-        bubT1_chempot2 = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(nonvolatiles=["calcium","chloride"]))[1]
+        bubT1_chempot2 = bubble_temperature(model1, 101325, x1, ChemPotBubbleTemperature(nonvolatiles=["calcium","chloride"]))[1]
         @test_broken bubT1_chempot2 ≈ bub_test rtol = 1e-6
 
-        bubT1_2 = bubble_temperature(model1, 101325, x, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"],y0=[1.,0.,0.],vol0=(1.8e-5,1.),T0=373.15))[1]
+        bubT1_2 = bubble_temperature(model1, 101325, x1, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"],y0=[1.,0.,0.],vol0=(1.8e-5,1.),T0=373.15))[1]
         @test bubT1_2 ≈ bub_test rtol = 1e-6
 
         bubP1 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"],y0=[1.,0.,0.],vol0=(1e-5,1.)))

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -41,8 +41,8 @@
             bondvol = Dict([(("NH2","H"),("NH2","e")) => 95.225e-30,
                             (("CO2","a1"),("NH2","e")) => 3280.3e-30,
                             (("CO2","a2"),("NH2","e")) => 142.64e-30])))
-        
-        
+
+
         bondvol_mixed = model_mix.vrmodel.params.bondvol[1,2]
         @test length(bondvol_mixed) == 2
         @test vec(bondvol_mixed) ≈ [1.4264e-28, 3.2803e-27]
@@ -229,7 +229,7 @@
         #@test γ1[1] ≈ 55334.605821130834 rtol = 1e-4
 
         @test γ1[1] ≈ 51930.06908022231 rtol = 1e-4
-        
+
     end
 
     @testset "#262" begin
@@ -342,13 +342,13 @@
 
         bubT1_chempot = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(T0=373.0, nonvolatiles=["calcium","chloride"]))[1]
         @test_broken bubT1_chempot ≈ bub_test rtol = 1e-6
-        
+
         bubT1_chempot2 = bubble_temperature(model1, 101325, x, ChemPotBubbleTemperature(nonvolatiles=["calcium","chloride"]))[1]
         @test_broken bubT1_chempot2 ≈ bub_test rtol = 1e-6
 
         bubT1_2 = bubble_temperature(model1, 101325, x, FugBubbleTemperature(nonvolatiles = ["calcium", "chloride"],y0=[1.,0.,0.],vol0=(1.8e-5,1.),T0=373.15))[1]
         @test bubT1_2 ≈ bub_test rtol = 1e-6
-        
+
         bubP1 = bubble_pressure(model1,298.15,x1,FugBubblePressure(nonvolatiles=["calcium","chloride"],y0=[1.,0.,0.],vol0=(1e-5,1.)))
         @test bubP1 ≈ bubP1_test rtol = 1e-6
 

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -93,7 +93,7 @@
         #water-oxygen system, non-condensables
         model_a_ideal = CompositeModel(["water","oxygen"],liquid = RackettLiquid,gas = BasicIdeal,saturation = DIPPR101Sat)
         @test Clapeyron.tp_flash(model_a_ideal,134094.74892634258,70 + 273.15,[18500.0, 24.08],noncondensables = ["oxygen"])[1] ≈
-        [1.0 0.0; 
+        [1.0 0.0;
         0.23252954843762222 0.7674704515623778] rtol = 1e-6
     end
 
@@ -279,7 +279,7 @@ end
     fluids= ["isopentane","isobutane"]
     model = cPR(fluids,idealmodel=ReidIdeal)
 
-    p = 2*101325.0; z = [2.0,5.0]; 
+    p = 2*101325.0; z = [2.0,5.0];
     q = 0.062744140625
     res_qp3 = qp_flash(model,q,p,z)
     res_qp4 = qp_flash(model,q,p,z./10)
@@ -517,6 +517,9 @@ end
         (Tb,vlb,vvb,yb) = bubble_temperature(system2,p,x0,ChemPotBubbleTemperature(y0 = y0,T0 = T,nonvolatiles = ["decane"]))
         @test Tb  ≈ Tres1 rtol = 1E-6
         @test yb[4] == 0.0
+        #test if the nonvolatile neq system is being built
+        (Tc,vlc,vvc,yc) = bubble_temperature(system2,p,x0,FugBubbleTemperature(itmax_newton = 1, y0 = y0,T0 = T,nonvolatiles = ["decane"]))
+        @test Tc isa Number
     end
     GC.gc()
 


### PR DESCRIPTION
instead of fully splitting the models, and then trying to check if the model is used or not, we just use a list of models currently used in equilibria. Adds some utilities for handling ForwardDiff v1 that were necessary to fix #357.

fixes #357 , adds tests.