### PR TITLE
Generate generic SAFTgammaParam and hence model compatability with AD

### DIFF
--- a/src/database/ClapeyronParam.jl
+++ b/src/database/ClapeyronParam.jl
@@ -26,7 +26,7 @@ is_splittable(::OptionsParam) = false
 export EoSParam, ParametricEoSParam
 
 paramtype(m::ClapeyronParam) = eltype(m)
-paramtype(::Type{M}) where M <: ClapeyronParam = eltype(m)
+paramtype(::Type{M}) where M <: ClapeyronParam = eltype(M)
 
 custom_show(param::EoSParam) = _custom_show_param(typeof(param))
 

--- a/src/database/combiningrules.jl
+++ b/src/database/combiningrules.jl
@@ -132,7 +132,7 @@ Ignores non-diagonal entries already set.
 If a Single Parameter is passed as input, it will be converted to a Pair Parameter with `λᵢᵢ = λᵢ`.
 """
 function lambda_LorentzBerthelot(lambda::SingleOrPair,k = 3)
-    param = PairParam(lambda.name,lambda.components,float.(lambda.values),lambda.ismissingvalues,lambda.sourcecsvs,lambda.sources)
+    param = PairParam(lambda.name,lambda.components,lambda.values,lambda.ismissingvalues,lambda.sourcecsvs,lambda.sources)
     return lambda_LorentzBerthelot!(param,k)
 end
 

--- a/src/database/combiningrules/group.jl
+++ b/src/database/combiningrules/group.jl
@@ -163,8 +163,8 @@ end
 
 function group_pairmean(f::F,groups,p::AbstractArray) where {F}
     v = __get_group_sum_values(groups)
-    _0 = zero(Base.promote_eltype(1.0,p,v[1])) #we want a float type
-    res = fill(_0,length(groups.components))
+    T = Base.promote_eltype(1.0,p,v[1])
+    res = zeros(T, length(groups.components))
     return group_pairmean!(res,f,groups,p)
 end
 

--- a/src/database/combiningrules/outplace.jl
+++ b/src/database/combiningrules/outplace.jl
@@ -20,7 +20,7 @@ Ignores non-diagonal entries already set.
 If a Single Parameter is passed as input, it will be converted to a Pair Parameter with `pᵢᵢ = pᵢ`.
 """
 function kij_mix(f::F,P::SingleOrPair,K = nothing) where F
-    param = PairParam(P.name,P.components,float.(P.values),P.ismissingvalues,P.sourcecsvs,P.sources)
+    param = PairParam(P.name,P.components,P.values,P.ismissingvalues,P.sourcecsvs,P.sources)
     return kij_mix!(f,param,K)
 end
 
@@ -46,6 +46,6 @@ If you pass a `SingleParam` or a vector as input for `Q`, then `Qᵢⱼ` will be
 ```
 """
 function pair_mix(f::F,P::SingleOrPair,Q::SingleOrPair) where F
-    param = PairParam(P.name,P.components,float.(P.values),P.ismissingvalues,P.sourcecsvs,P.sources)
+    param = PairParam(P.name,P.components,P.values,P.ismissingvalues,P.sourcecsvs,P.sources)
     return pair_mix!(f,param,Q)
 end

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -261,12 +261,12 @@ function Base.show(io::IO, ::MIME"text/plain", param::MixedGCSegmentParam)
     show_pairs(io,param.components,param.values,separator)
 end
 
-function MixedGCSegmentParam{T}(group::GroupParam,s = FillArrays.Fill(oneunit(T),length(groups.flattenedgroups)),segment = FillArrays.Fill(oneunit(T),length(groups.flattenedgroups))) where T <: Number
+function MixedGCSegmentParam{T}(group::GroupParam,s = ones(T, length(groups.flattenedgroups)),segment = ones(T, length(groups.flattenedgroups))) where T <: Number
     name = "mixed segment"
     components = group.components
     nc = length(components)
     ng = length(group.flattenedgroups)
-    values = PackedVectorsOfVectors.packed_fill(zero(T),FillArrays.fill(ng,nc))
+    values = Clapeyron.PackedVectorsOfVectors.pack([zeros(T, ng) for _ in 1:nc])
     n_flattenedgroups = group.n_flattenedgroups
     for i in 1:nc
         val_i = values[i]

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -261,7 +261,7 @@ function Base.show(io::IO, ::MIME"text/plain", param::MixedGCSegmentParam)
     show_pairs(io,param.components,param.values,separator)
 end
 
-function MixedGCSegmentParam{T}(group::GroupParam,s = ones(T, length(groups.flattenedgroups)),segment = ones(T, length(groups.flattenedgroups))) where T <: Number
+function MixedGCSegmentParam{T}(group::GroupParam,s = ones(T, length(group.flattenedgroups)),segment = ones(T, length(group.flattenedgroups))) where T <: Number
     name = "mixed segment"
     components = group.components
     nc = length(components)

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -159,7 +159,7 @@ function SAFTgammaMie(components;
     
     segment = params["vst"]
     shapefactor = params["S"]
-    mixed_segment = MixedGCSegmentParam(groups,shapefactor.values,segment.values)
+    mixed_segment = MixedGCSegmentParam{Base.eltype(shapefactor)}(groups,shapefactor.values,segment.values)
     sigma = sigma_LorentzBerthelot(params["sigma"])
     sigma.values .*= 1E-10
     sigma3 = PairParam(sigma)
@@ -239,7 +239,7 @@ function SAFTVRMie(groups::GroupParam,param::SAFTgammaMieParam,sites::SiteParam 
     comp_sites = gc_to_comp_sites(sites,groups)
     comp_bondvol = gc_to_comp_sites(gc_bondvol,comp_sites)
     comp_epsilon_assoc = gc_to_comp_sites(gc_epsilon_assoc,comp_sites)
-    Mw = SingleParam("Mw",components)
+    Mw = SingleParam("Mw",components, zeros(eltype(shapefactor), length(groups.components)))
     vrparams = SAFTVRMieParam(Mw,segment,sigma,lambda_a,lambda_r,epsilon,comp_epsilon_assoc,comp_bondvol)
     return SAFTVRMie(components,comp_sites,vrparams,idealmodel,assoc_options,default_references(SAFTVRMie))
 end

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -258,7 +258,9 @@ function SAFTVRMie(groups::GroupParam,param::SAFTgammaMieParam,sites::SiteParam 
     comp_sites = gc_to_comp_sites(sites,groups)
     comp_bondvol = gc_to_comp_sites(gc_bondvol,comp_sites)
     comp_epsilon_assoc = gc_to_comp_sites(gc_epsilon_assoc,comp_sites)
-    Mw = SingleParam("Mw",components, zeros(eltype(shapefactor), length(groups.components)))
+    Mw = get(params,"Mw") do
+      SingleParam("Mw",components, zeros(eltype(shapefactor), length(groups.components)))
+    end
     vrparams = SAFTVRMieParam(Mw,segment,sigma,lambda_a,lambda_r,epsilon,comp_epsilon_assoc,comp_bondvol)
     return SAFTVRMie(components,comp_sites,vrparams,idealmodel,assoc_options,default_references(SAFTVRMie))
 end

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -154,6 +154,25 @@ function SAFTgammaMie(components;
 
     groups = GroupParam(components, ["SAFT/SAFTgammaMie/SAFTgammaMie_groups.csv"]; group_userlocations = group_userlocations,verbose = verbose)
     params = getparams(groups, ["SAFT/SAFTgammaMie","properties/molarmass_groups.csv"]; userlocations = userlocations, verbose = verbose)
+
+    return SAFTgammaMie(groups, params;
+                        idealmodel = idealmodel,
+                        ideal_userlocations = ideal_userlocations,
+                        reference_state = reference_state,
+                        verbose = verbose,
+                        epsilon_mixing = epsilon_mixing,
+                        assoc_options = assoc_options)
+end
+
+function SAFTgammaMie(groups::GroupParam, params::Dict{String,ClapeyronParam};
+    idealmodel = BasicIdeal,
+    ideal_userlocations = String[],
+    reference_state = nothing,
+    verbose = false,
+    epsilon_mixing = :default,
+    assoc_options = AssocOptions())
+
+    
     sites = params["sites"]
     components = groups.components
     

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -258,9 +258,7 @@ function SAFTVRMie(groups::GroupParam,param::SAFTgammaMieParam,sites::SiteParam 
     comp_sites = gc_to_comp_sites(sites,groups)
     comp_bondvol = gc_to_comp_sites(gc_bondvol,comp_sites)
     comp_epsilon_assoc = gc_to_comp_sites(gc_epsilon_assoc,comp_sites)
-    Mw = get(params,"Mw") do
-      SingleParam("Mw",components, zeros(eltype(shapefactor), length(groups.components)))
-    end
+    Mw = SingleParam("Mw",components, zeros(eltype(shapefactor), length(groups.components)))
     vrparams = SAFTVRMieParam(Mw,segment,sigma,lambda_a,lambda_r,epsilon,comp_epsilon_assoc,comp_bondvol)
     return SAFTVRMie(components,comp_sites,vrparams,idealmodel,assoc_options,default_references(SAFTVRMie))
 end


### PR DESCRIPTION
Implements changes in issue https://github.com/ClapeyronThermo/Clapeyron.jl/issues/370

And exposes method for `SAFTgammaMie(::GroupParam, ::Dict{String,ClapeyronParam)` from discussion https://github.com/ClapeyronThermo/Clapeyron.jl/discussions/352