### PR TITLE
Association NRTL r_i values fix

### DIFF
--- a/database/Activity/NRTL/NRTL_assoc.csv
+++ b/database/Activity/NRTL/NRTL_assoc.csv
@@ -3,9 +3,9 @@ NRTL Assoc Parameters [csvtype = like],,,,,
 species,δA,δD,nA,nD,rI
 chloroform,0,0.145,0,1,2.87
 p-cresol,0,5.234,0,1,4.29
-cyclohexane,0,0,0,0,4.05
+cyclohexane,0,0,0,0,5.423
 dimethyl sulfoxide,3.387,0,2,0,2.83
-n-hexane,0,0,0,0,4.5
+n-hexane,0,0,0,0,5.45
 methanol,1,1,2,1,1.43
 n-octane,0,0,0,0,5.85
 water,1,1,2,2,0.76

--- a/src/models/Activity/NRTL/variants/NRTL assoc.jl
+++ b/src/models/Activity/NRTL/variants/NRTL assoc.jl
@@ -73,7 +73,7 @@ function NRTLAssoc(components; puremodel=PR,
 
     _puremodel = init_puremodel(puremodel,components,pure_userlocations,verbose)
     packagedparams = NRTLAssocParam(a,b,c,Mw,δA,δD,nA,nD,rI)
-    references = String["10.1002/aic.690140124"]
+    references = String["10.1002/aic.690140124", "10.1002/aic.17061"]
     model = NRTLAssoc(formatted_components,packagedparams,_puremodel,references)
     set_reference_state!(model,reference_state,verbose = verbose)
     return model


### PR DESCRIPTION
Changed values from r_i parameters for n-hexane and cyclohexane. Added in model code reference to paper.