### PR TITLE
Doc maintain

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@ CurrentModule = Clapeyron
 # Clapeyron.jl
 
 An extensible [Julia](https://julialang.org) package for the modelling of fluids using thermodynamic equations of state.
-These include the standard cubics (van der Waals, Redlich–Kwong, Peng–Robinson, etc.), SAFT-type equations (PC‑SAFT, SAFT‑VR Mie, SAFT‑$\gamma$ Mie, etc.), empirical equations (GERG‑2008, IAPWS‑95), Activity coefficient models (NRTL, UNIFAC, COSMO‑SAC, etc.) and many more.
+These include the standard cubics (van der Waals, Redlich–Kwong, Peng–Robinson, etc.), SAFT-type equations (PC‑SAFT, SAFT‑VR Mie, SAFT‑$\gamma$ Mie, etc.), empirical equations (GERG‑2008, IAPWS‑95), activity coefficient models (NRTL, UNIFAC, COSMO‑SAC, etc.) and many more.
 
 The documentation is laid out as follows:
 

--- a/docs/src/tutorials/binary_phase_diagrams.md
+++ b/docs/src/tutorials/binary_phase_diagrams.md
@@ -250,6 +250,7 @@ Contains parameters: Mw, segment, sigma, lambda_a, lambda_r, epsilon, epsilon_as
 ```
 
 For this system, the only interesting composition range is up to 3\% mole fraction of carbon dioxide in the liquid phase:
+
 ![co2_h2o_pxy](../assets/co2_h2o_pxy.png)
 
 Going much beyond this composition range, particularly when one reaches pressures in GPa, will typically encounter numerical issues.
@@ -338,10 +339,12 @@ Contains parameters: Mw, segment, sigma, epsilon, epsilon_assoc, bondvol
 
 If we just blindly plot the *pxy* (or *Txy*) diagram, we will see some unphysical behaviour:
 ![water_pentoh_pxy_wrong](../assets/water_pentoh_pxy_wrong.png)
+
 One can see the presence of an unphysical crossover in the dew curve, as well as a maxima in the bubble curve.
 These are the tell-tale signs of the presence of VLLE at these conditions.
 Something similar also occurs in the *Txy* diagram:
 ![water_pentoh_Txy_wrong](../assets/water_pentoh_Txy_wrong.png)
+
 Once VLLE has been identified, to solve for its exact state, we can use the `VLLE_pressure(model, T)` / `VLLE_temperature(model, p)` functions.
 Unfortunately, generating good initial guesses automatically is very challenging.
 As such, users will need to provide decent initial guesses.
@@ -528,6 +531,7 @@ end
 For simple mixtures, one doesn't need to update the initial guesses.
 And with that, we have now drawn the *pT* projection for this mixture:
 ![eth_dec_pT_mix](../assets/eth_dec_pT_mix.png)
+
 Unfortunately, this is the simplest type of *pT* projection one can draw.
 
 ### Type-II mixture
@@ -561,7 +565,8 @@ end
 
 With this, the plot looks like:
 ![cyhex_meoh_pT_mix](../assets/cyhex_meoh_pT_mix.png)
-The critical curve may look a bit odd but it is physical (as a challenge, try to draw the *pxy* phase diagram around 500K).
+
+The critical curve may look a bit odd but it is physical (as a challenge, try to draw the *pxy* phase diagram around 500 K).
 
 What makes type-II mixtures unique is the fact that these system exhibit VLLE behaviour, typically at low temperatures.
 Due to the Gibbs Phase Rule, there is only a single pressure at a given temperature that VLLE occurs.
@@ -623,6 +628,7 @@ end
 
 And with this, we can complete the phase diagram:
 ![cyhex_meoh_pT_full](../assets/cyhex_meoh_pT_full.png)
+
 Note that there is no formal definition for where the azeotrope meets the critical curve.
 Thus the end point must be determined ahead of time.
 
@@ -637,11 +643,13 @@ julia> model = GERG2008(["heptane","methane"])
 Type-III mixtures are unique as the critical curve is broken into two.
 If one starts from the less volatile component, we find that the curve does not reconnect with the critical point of the more volatile component:
 ![me_hept_pT_1](../assets/me_hept_pT_1.png)
+
 Eventually, this curve becomes the UCST curve.
 However, there is a critical curve originating from the more volatile component
 However, this time, it terminates at the UCEP.
 We can repeat the same steps as above to obtain the UCEP:
 ![me_hept_pT](../assets/me_hept_pT.png)
+
 Especially in cases with very different volatilities, it will be very difficult to see the separation between the VLLE, critical and saturation curve as shown above.
 However, if one zooms in, we can see the three independent curves:
 ![me_hept_pT_zoom](../assets/me_hept_pT_zoom.png)
@@ -662,6 +670,7 @@ julia> model = PR(["hexane","methane"])
 
 Examining the critical curve originating from the less-volatile component:
 ![me_hex_pT_1](../assets/me_hex_pT_1.png)
+
 As we can see, the critical curve overshoots the critical point of the more volatile component.
 This critical curve will terminate at the first UCEP.
 The critical curve originating from the more volatile component will terminate at a second UCEP.
@@ -669,5 +678,7 @@ Connecting the two UCEPs will be the VLLE curve.
 We have described all the tools needed to trace these curves in earlier section.
 The result should look like:
 ![me_hex_pT_full](../assets/me_hex_pT_full.png)
+
 Zooming in to the UCEPs, we see that, much like the previous example, the VLLE curve is very close to the saturation curve of the less-volatile component:
+
 ![me_hex_pT_zoom](../assets/me_hex_pT_zoom.png)

--- a/docs/src/user_guide/basic_usage.md
+++ b/docs/src/user_guide/basic_usage.md
@@ -277,6 +277,7 @@ The functions for the physical properties that we currently support are as follo
   Cp = isobaric_heat_capacity(model, p, T, z)
   betaT = thermal_compressibility(model, p, T, z)
   betaS = isentropic_compressibility(model, p, T, z)
+  adiabatic_index = adiabatic_index(model, p, T, z)
   u = speed_of_sound(model, p, T, z)
   alphaV = isobaric_expansivity(model, p, T, z)
   muJT = joule_thomson_coefficient(model, p, T, z)

--- a/src/base/EoSModel.jl
+++ b/src/base/EoSModel.jl
@@ -27,11 +27,11 @@ Rgas() = R̄
 Returns the total Helmholtz free energy.
 # Inputs:
 - `model::EoSModel` Thermodynamic model to evaluate
-- `V` Total volume, in [m³]
-- `T` Temperature, in [K]
-- `z` mole amounts, in [mol], by default is `@SVector [1.0]`
+- `V` Total volume, in `[m³]`
+- `T` Temperature, in `[K]`
+- `z` mole amounts, in `[mol]`, by default is `@SVector [1.0]`
 # Outputs:
-- Total Helmholtz free energy, in [J]
+- Total Helmholtz free energy, in `[J]`
 by default, it calls `R̄*T*∑(z)*(a_ideal(ideal_model,V,T,z) + a_res(model,V,T,z))` where `ideal_model == idealmodel(model)`, where `a_res` is the reduced residual Helmholtz energy and `a_ideal` is the reduced ideal Helmholtz energy.
 You can mix and match ideal models if you provide:
 - `[idealmodel](@ref)(model)`: extracts the ideal model from your Thermodynamic model
@@ -76,11 +76,11 @@ end
 Returns the residual Helmholtz free energy.
 # Inputs:
 - `model::EoSModel` Thermodynamic model to evaluate
-- `V` Total volume, in [m³]
-- `T` Temperature, in [K]
-- `z` mole amounts, in [mol], by default is `@SVector [1.0]`
+- `V` Total volume, in `[m³]`
+- `T` Temperature, in `[K]`
+- `z` mole amounts, in `[mol]`, by default is `@SVector [1.0]`
 # Outputs:
-- Residual Helmholtz free energy, in [J]
+- Residual Helmholtz free energy, in `[J]`
 by default, it calls `R̄*T*∑(z)*(a_res(model,V,T,z))` where [`a_res`](@ref) is the reduced residual Helmholtz energy.
 """
 function eos_res(model::EoSModel, V, T, z=SA[1.0])
@@ -90,12 +90,12 @@ end
 
 """
     a_res(model::EoSModel, V, T, z,args...)
-Reduced residual Helmholtz free energy.
+Returns reduced residual Helmholtz free energy.
 # Inputs:
 - `model::EoSModel` Thermodynamic model to evaluate
-- `V` Total volume, in [m³]
-- `T` Temperature, in [K]
-- `z` mole amounts, in [mol], by default is `@SVector [1.0]`
+- `V` Total volume, in `[m³]`
+- `T` Temperature, in `[K]`
+- `z` mole amounts, in `[mol]`, by default is `@SVector [1.0]`
 # Outputs:
 - Residual Helmholtz free energy, no units
 You can define your own EoS by adding a method to `a_res` that accepts your custom model.
@@ -198,7 +198,7 @@ end
 """
     default_references(::Type{<:EoSModel})::Vector{String}
 
-Return the default references of a model. If you are using the `@newmodel`, `@newmodelsimple` or `@newmodelgc` macros, define this function to set the references for the defined EoS.
+Returns the default references of a model. If you are using the `@newmodel`, `@newmodelsimple` or `@newmodelgc` macros, define this function to set the references for the defined EoS.
 
 """
 function default_references end
@@ -260,7 +260,7 @@ end
 
 """
     recombine!(model::EoSModel)
-Recalculate all mixing rules, combining rules and parameter caches inside an `EoSModel`.
+Recalculates all mixing rules, combining rules and parameter caches inside an `EoSModel`.
 """
 function recombine! end
 

--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -1,7 +1,7 @@
-const N_A = 6.02214076e23 # mol-1
+const N_A = 6.02214076e23 # mol⁻¹
 const ln_N_A = 54.75489994294367 #log(N_A)
-const k_B = 1.380649e-23 # m2 kg s-2 K-1
-const R̄   = N_A*k_B # m2 kg s-2 K-1 mol-1
+const k_B = 1.380649e-23 # m² kg s⁻² K⁻¹
+const R̄   = N_A*k_B # m² kg s⁻² K⁻¹ mol⁻¹
 const ħ = 1.054571817e-34 # J s
 const h = 1.054571817e-34*2*π # J s
 const SingleComp = Union{SVector{1, Float64},Float64,Int64}

--- a/src/base/errors.jl
+++ b/src/base/errors.jl
@@ -18,7 +18,7 @@ end
 """
     binary_component_check(method,model)
 
-Checks if a model is a single component model, throws an error otherwise.
+Checks if a model is a binary component model, throws an error otherwise.
 """
 function binary_component_check(method,model)
     l = length(model)

--- a/src/methods/differentials.jl
+++ b/src/methods/differentials.jl
@@ -7,7 +7,7 @@
 """
     ∂f∂T(model,V,T,z=SA[1.0])
 
-returns `∂f/∂T` at constant total volume and composition, where f is the total helmholtz energy, given by `eos(model,V,T,z)`
+Returns `∂f/∂T` at constant total volume and composition, where f is the total helmholtz energy, given by `eos(model,V,T,z)`.
 
 """
 function ∂f∂T(model,V,T,z::AbstractVector)
@@ -18,7 +18,7 @@ end
 """
     ∂f∂V(model,V,T,z)
 
-returns `∂f/∂V` at constant temperature and composition, where f is the total helmholtz energy, given by `eos(model,V,T,z)`, and V is the total volume
+Returns `∂f/∂V` at constant temperature `T` and composition `z`, where `f` is the total helmholtz energy, given by `eos(model,V,T,z)`, `V` is the total volume.
 """
 function ∂f∂V(model,V,T,z::AbstractVector)
     f(∂V) = a_res(model,∂V,T,z)
@@ -26,12 +26,12 @@ function ∂f∂V(model,V,T,z::AbstractVector)
     sum(z)*Rgas(model)*T*(∂aᵣ∂V - 1/V)
 end
 
-#returns a tuple of the form ([∂f∂V,∂f∂T],f),using the least amount of computation
+#Returns a tuple of the form ([∂f∂V,∂f∂T],f),using the least amount of computation
 """
     ∂f(model,V,T,z)
 
-returns zeroth order (value) and first order derivative information of the total helmholtz energy (given by `eos(model,V,T,z)`).
-the result is given in two values:
+Returns zeroth order (value) and first order derivative information of the total helmholtz energy (given by `eos(model,V,T,z)`).
+The result is given in two values:
 
 ```julia
 grad_f,fval = ∂2f(model,V,T,z)
@@ -43,7 +43,6 @@ where:
 fval   = f(V,T) = eos(model,V,T,z)
 
 grad_f = [ ∂f/∂V; ∂f/∂T]
-
 ```
 
 Where `V` is the total volume, `T` is the temperature and `f` is the total helmholtz energy.
@@ -82,14 +81,14 @@ function ∂f_res_vec(model,V,T,z::AbstractVector)
     return SVector(_f,_df[1],_df[2])
 end
 
-#returns p and ∂p∂V at constant T
+#Returns p and ∂p∂V at constant T
 #it doesnt do a pass over temperature, so its
 #faster that d2f when only requiring d2fdV2
 
 """
     p∂p∂V(model,V,T,z=SA[1.0])
 
-returns `p` and `∂p/∂V` at constant temperature, where p is the pressure = `pressure(model,V,T,z)` and `V` is the total Volume.
+Returns `p` and `∂p/∂V` at constant temperature, where `p` is the pressure = `pressure(model,V,T,z)` and `V` is the total volume.
 
 """
 function p∂p∂V(model,V,T,z::AbstractVector=SA[1.0])
@@ -101,22 +100,22 @@ end
 """
     ∂2f(model,V,T,z)
 
-returns zeroth order (value), first order and second order derivative information of the total helmholtz energy (given by `eos(model,V,T,z)`).
-the result is given in three values:
+Returns zeroth order (value), first order and second order derivative information of the total helmholtz energy (given by `eos(model,V,T,z)`).
+The result is given in three values:
 
-```
+```julia
 hess_f,grad_f,fval = ∂2f(model,V,T,z)
 ```
 
 where:
-```
+```julia
 fval   = f(V,T) = eos(model,V,T,z)
 
 grad_f = [ ∂f/∂V; ∂f/∂T]
 
 hess_f = [ ∂²f/∂V²; ∂²f/∂V∂T
           ∂²f/∂V∂T; ∂²f/∂V²]
- ```
+```
 
 Where `V` is the total volume, `T` is the temperature and `f` is the total helmholtz energy.
 """
@@ -129,22 +128,22 @@ end
 """
     ∂2p(model,V,T,z)
 
-returns zeroth order (value), first order and second order derivative information of the pressure.
+Returns zeroth order (value), first order and second order derivative information of the pressure.
 the result is given in three values:
 
-```
+```julia
 hess_p,grad_p,pval = ∂2p(model,V,T,z)
 ```
 
 where:
-```
+```julia
 pval   = p(V,T) = pressure(model,V,T,z)
 
 grad_p = [ ∂p/∂V; ∂p/∂T]
 
 hess_p = [ ∂²p/∂V²; ∂²p/∂V∂T
           ∂²p/∂V∂T; ∂²p/∂V²]
- ```
+```
 
 Where `V` is the total volume, `T` is the temperature and `p` is the pressure.
 """
@@ -157,14 +156,14 @@ end
 """
     f_hess(model,V,T,z)
 
-returns the second order volume (`V`) and temperature (`T`) derivatives of the total helmholtz energy (given by `eos(model,V,T,z)`). the result is given in a 2x2 `SMatrix`, in the form:
+Returns the second order volume (`V`) and temperature (`T`) derivatives of the total helmholtz energy `f` (given by `eos(model,V,T,z)`). The result is given in a 2x2 `SMatrix`, in the form:
 
-```
+```julia
 [ ∂²f/∂V²  ∂²f/∂V∂T
  ∂²f/∂V∂T  ∂²f/∂T²]
- ```
+```
 
-use this instead of the ∂2f if you only need second order information. ∂2f also gives zeroth and first order derivative information, but due to a bug in the used AD, it allocates more than necessary.
+Use this instead of the `∂2f` if you only need second order information. `∂2f` also gives zeroth and first order derivative information, but due to a bug in the used AD, it allocates more than necessary.
 """
 function f_hess(model,V,T,z)
     f(w) = eos(model,first(w),last(w),z)
@@ -176,7 +175,7 @@ end
 """
     ∂²³f(model,V,T,z=SA[1.0])
 
-returns `∂²A/∂V²` and `∂³A/∂V³`, in a single ForwardDiff pass. used mainly in `crit_pure` objective function
+Returns `∂²A/∂V²` and `∂³A/∂V³`, in a single ForwardDiff pass. Used mainly in `crit_pure` objective function.
 
 """
 function ∂²³f(model,V,T,z=SA[1.0])
@@ -188,7 +187,7 @@ end
 """
     ∂²f∂T²(model,V,T,z=SA[1.0])
 
-returns `∂²A/∂T²` via Autodiff. Used mainly for ideal gas properties. It is recommended to overload this function for ideal models, as is equivalent to -Cv(T)/T
+Returns `∂²A/∂T²` via Autodiff. Used mainly for ideal gas properties. It is recommended to overload this function for ideal models, as is equivalent to -Cv(T)/T.
 
 """
 function ∂²f∂T²(model,V,T,z)
@@ -212,7 +211,7 @@ const _d23f = ∂²³f
 
 #as of Clapeyron 0.6.10, there is limited support for using models with dual numbers
 #PCSAFT, sPCSAFT, SAFTVRMie, SAFTVRMie15 support using dual numbers, (and any other number type)
-#for iterative methods, it is more efficient to reconstruct the model with the primal value instead of the full value
+#for iterative methods, it is more efficient to reconstruct the model with the primal value instead of the full value.
 
 function Solvers.primalval(model::EoSModel)
     return _primalval(model,eltype(model))

--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -2,7 +2,7 @@
     x0_volume_liquid(model,T,z)
     x0_volume_liquid(model,p,T,z)
 
-Returns an initial guess to the liquid volume, dependent on temperature and composition. by default is 1.25 times [`lb_volume`](@ref).
+Returns an initial guess to the liquid volume, dependent on temperature and composition. By default is 1.25 times [`lb_volume`](@ref).
 """
 function x0_volume_liquid(model,T,z)
     v_lb = lb_volume(model,T,z)
@@ -14,7 +14,7 @@ x0_volume_liquid(model,T) = x0_volume_liquid(model,T,SA[1.0])
 """
     x0_volume_gas(model,p,T,z)
 
-Returns an initial guess to the gas volume, depending of pressure, temperature and composition. by default uses [`volume_virial`](@ref)
+Returns an initial guess to the gas volume, depending of pressure, temperature and composition. By default uses [`volume_virial`](@ref)
 """
 function x0_volume_gas(model,p,T,z)
     B = second_virial_coefficient(model,T,z)
@@ -34,7 +34,7 @@ x0_volume_gas(model,p,T) = x0_volume_gas(model,p,T,SA[1.0])
     x0_volume_solid(model,T,z)
     x0_volume_solid(model,p,T,z)
 
-Returns an initial guess to the solid volume, dependent on temperature and composition. needs to be defined for EoS that support solid phase. by default returns NaN. can be overrided if the EoS defines `is_solid(::EoSModel) = true`
+Returns an initial guess to the solid volume, dependent on temperature and composition. Needs to be defined for EoS that support solid phase. By default returns NaN. Can be overrided if the EoS defines `is_solid(::EoSModel) = true`
 """
 function x0_volume_solid(model,T,z)
     if is_solid(model)
@@ -54,7 +54,7 @@ Returns an initial guess of the volume at a pressure, temperature, composition a
 If the suggested phase is `:unknown` or `:liquid`, calls [`x0_volume_liquid`](@ref).
 If the suggested phase is `:gas`, calls [`x0_volume_gas`](@ref).
 If the suggested phase is `solid`, calls [`x0_volume_solid`](@ref).
-Returns `NaN` otherwise
+Returns `NaN` otherwise.
 """
 function x0_volume(model, p, T, z = SA[1.0]; phase = :unknown)
     return x0_volume_impl(model,p,T,z,phase)
@@ -84,8 +84,8 @@ Returns the lower bound volume.
 It has different meanings depending on the Equation of State, but symbolizes the minimum allowable volume at a certain composition:
 - SAFT EoS: the packing volume
 - Cubic EoS, covolume (b) parameter
-On empiric equations of state, the value is chosen to match the volume of the conditions at maximum pressure and minimum temperature
-, but the equation itself normally can be evaluated at lower volumes.
+On empiric equations of state, the value is chosen to match the volume of the conditions at maximum pressure and minimum temperature,
+but the equation itself normally can be evaluated at lower volumes.
 On SAFT and Cubic EoS, volumes lower than `lb_volume` will likely error.
 The lower bound volume is used for guesses of liquid volumes at a certain pressure, saturated liquid volumes and critical volumes.
 
@@ -125,7 +125,7 @@ function p_scale(model,z)
 end
 """
     antoine_coef(model)
-should return a 3-Tuple containing reduced Antoine Coefficients. The Coefficients follow the correlation:
+Should return a 3-Tuple containing reduced Antoine Coefficients. The Coefficients follow the correlation:
 ```
 lnp̄ = log(p / p_scale(model))
 T̃ = T/T_scale(model)
@@ -150,7 +150,7 @@ saturation_model(model::T) where T = model
 
 Used to indicate if a model can calculate their critical point without iterative calculations.
 Having a critical point available results in speed ups for saturation calculations.
-By default returns `false`
+By default returns `false`.
 """
 function has_fast_crit_pure(model)::Bool
     satmodel = saturation_model(model)
@@ -206,7 +206,7 @@ end
     p,vl,vv = x0_sat_pure_virial(model,T)
 
 Calculates initial points for pure saturation pressure using a virial + corresponding states approach.
-the corresponding states model (a vdW fluid fitted from 2 p-V points) is used to select between zero-pressure or spinodal initial points.
+The corresponding states model (a vdW fluid fitted from 2 p-V points) is used to select between zero-pressure or spinodal initial points.
 The points selected to fit the vdW fluid are a function of B(T).
 """
 function x0_sat_pure_virial(model,T)
@@ -372,7 +372,7 @@ end
                                 refine_vl = true)
 
 Calculates initial points for pure saturation pressure, using a zero-pressure volume approach.
-If `refine_vl` is set to `true`, then the liquid volume will be recalculated using the calculated saturation pressure,otherwise it will be returned as is.
+If `refine_vl` is set to `true`, then the liquid volume will be recalculated using the calculated saturation pressure, otherwise it will be returned as is.
 """
 function x0_sat_pure_near0(model, T, vl0 = volume(model,zero(T),T,phase = :l);B = second_virial_coefficient(model,T), refine_vl = true)
     R̄ = Rgas(model)
@@ -766,7 +766,7 @@ end
 Initial point for saturation pressure, given the temperature and V,T critical coordinates.
 On moderate pressures it will use a Zero Pressure initialization. On pressures near the critical point it will switch to spinodal finding.
 Used in [`saturation_pressure`](@ref) methods that require initial pressure guesses.
-if the initial temperature is over the critical point, it returns `NaN`.
+If the initial temperature is over the critical point, it returns `NaN`.
 It can be overloaded to provide more accurate estimates if necessary.
 """
 function x0_psat(model,T)

--- a/src/methods/methods.jl
+++ b/src/methods/methods.jl
@@ -3,7 +3,7 @@
 
 Abstract type for all thermodynamic methods.
 
-normally, a thermodynamic method has the form: `property(model,state..,method::ThermodynamicMethod)`.
+Normally, a thermodynamic method has the form: `property(model,state..,method::ThermodynamicMethod)`.
 All methods used in this way subtype `ThermodynamicMethod`.
 
 ## Examples
@@ -128,7 +128,7 @@ const SOLID_STR = (:solid,:SOLID,:s)
     is_solid(x::EoSModel)
 
 Returns `true` if the symbol is in `(:solid,:SOLID,:s)`.
-if `x` is an `EoSModel`, it will return if the model is able to contain a solid phase. In this case, defaults to `false`
+If `x` is an `EoSModel`, it will return `true` if the model is able to contain a solid phase. In this case, defaults to `false`.
 If a string is passed, it is converted to symbol.
 """
 is_solid(sym::Symbol) = sym in SOLID_STR
@@ -201,7 +201,7 @@ end
     @nan(function_call,default=NaN)
 
 Wraps the function in a `try-catch` block, and if a `DomainError` or `DivideError` is raised, then returns `default`.
-for better results, its best to generate the default result beforehand
+For better results, its best to generate the default result beforehand.
 """
 macro nan(Base.@nospecialize(fcall),default = nothing)
     quote
@@ -252,14 +252,14 @@ function init_preferred_method(method,model) end
 
 Returns a matrix of "k-values" binary interaction parameters used by the input `model`. Returns `nothing` if the model cannot return the k-values matrix.
 In the case of multiple k-values (as is the case in T-dependent values, i.e: k(T) = k1 + k2*T), it will return a tuple of matrices corresponding to each term in the k-value expression.
-Note that some models do not store the k-value matrix directly, but they contain the value in an indirect manner. for example, cubic EoS store `a[i,j] = f(a[i],a[j],k[i,j])`, where `f` depends on the mixing rule.
+Note that some models do not store the k-value matrix directly, but they contain the value in an indirect manner. For example, cubic EoS store `a[i,j] = f(a[i],a[j],k[i,j])`, where `f` depends on the mixing rule.
 """
 get_k(model::EoSModel) = nothing
 
 """
     get_l(model)::VarArg{Matrix}
 
-returns a matrix of "l-values" binary interaction parameters used by the input `model`. Returns `nothing` if the model cannot return the l-values matrix.
+Returns a matrix of "l-values" binary interaction parameters used by the input `model`. Returns `nothing` if the model cannot return the l-values matrix.
 In the case of multiple l-values (as is the case in T-dependent values, i.e: l(T) = l1 + l2*T), it will return a tuple of matrices corresponding to each term in the l-value expression.
 Note that some models do not store the l-value matrix directly, but they contain the value in an indirect manner. for example, cubic EoS store `b[i,j] = f(b[i],b[j],l[i,j])`, where `f` depends on the mixing rule.
 """

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -42,7 +42,7 @@ end
 
 Performs a diffusive stability for a (V,T,z) pair, returns `true/false`.
 Checks if all eigenvalues of `∂²A/∂n²` are positive.
-Returns `false` if the eos calculation failed. Rhis normally occurs when evaluating on densities lower than the maximum density (given by `Clapeyron.lb_volume(model,T,z)`).
+Returns `false` if the eos calculation failed. This normally occurs when evaluating on densities lower than the maximum density (given by `Clapeyron.lb_volume(model,T,z)`).
 """
 function VT_diffusive_stability(model,V,T,z = SA[1.0])
     ρᵢ = similar(z,Base.promote_eltype(V,z))

--- a/src/methods/stability.jl
+++ b/src/methods/stability.jl
@@ -1,7 +1,7 @@
 """
     isstable(model,p,T,z)::Bool
 
-Performs stability tests for a (p,T,z) pair, and warn if any tests fail. returns `true/false`.
+Performs stability tests for a (p,T,z) pair, and warn if any tests fail. Returns `true/false`.
 
 Checks, in order of complexity:
  - mechanical stability: isothermal compressibility is not negative.
@@ -42,7 +42,7 @@ end
 
 Performs a diffusive stability for a (V,T,z) pair, returns `true/false`.
 Checks if all eigenvalues of `∂²A/∂n²` are positive.
-Returns `false` if the eos calculation failed. this normally occurs when evaluating on densities lower than the maximum density (given by `Clapeyron.lb_volume(model,T,z)`)
+Returns `false` if the eos calculation failed. Rhis normally occurs when evaluating on densities lower than the maximum density (given by `Clapeyron.lb_volume(model,T,z)`).
 """
 function VT_diffusive_stability(model,V,T,z = SA[1.0])
     ρᵢ = similar(z,Base.promote_eltype(V,z))
@@ -89,14 +89,14 @@ end
 """
     gibbs_duhem(model,V,T,z=[1.0])
 
-performs a Gibbs-Duhem check on the input conditions:
+Performs a Gibbs-Duhem check on the input conditions:
 
 ```
 ∑zᵢμᵢ - G ≈ 0
 ```
-Where `G` is the total gibbs energy. it can help diagnose if a user-defined eos is consistent.
+Where `G` is the total gibbs free energy. It can help diagnose if a user-defined eos is consistent.
 
-return |∑zᵢμᵢ - G|, ∑zᵢμᵢ and G at the specified conditions.
+Returns |∑zᵢμᵢ - G|, ∑zᵢμᵢ and G at the specified conditions.
 """
 function gibbs_duhem(model,V,T,z=SA[1.0])
     μ = dot(z,Clapeyron.VT_chemical_potential(model,V,T,z))
@@ -107,11 +107,11 @@ end
 """
     ideal_consistency(model,V,T,z=[1.0])
 
-performs a ideal model consistency check:
+Performs a ideal model consistency check:
 ```
 ∂a₀∂V + 1/V ≈ 0
 ```
-Where `∂a₀∂V` is the derivative of `a_ideal` respect to `V`. it can help diagnose if a user-defined ideal model is consistent.
+Where `∂a₀∂V` is the derivative of `a_ideal` respect to `V`. It can help diagnose if a user-defined ideal model is consistent.
 
 Return |∂a₀∂V + 1/V| at the specified conditions.
 

--- a/src/methods/tpd.jl
+++ b/src/methods/tpd.jl
@@ -139,7 +139,7 @@ end
     wl,wv = tpd_solver(model,p,T,z,K0)
 
 given p,T,z,K0, tries to perform a tangent-phase stability criterion with the given K value.
-it tries both liquid and vapour phase. returns the resulting compositions `wl` and `wv`.
+It tries both liquid and vapour phase. Returns the resulting compositions `wl` and `wv`.
 """
 function tpd_solver(model,p,T,z,K0,
     fz = mixture_fugacity(model,p,T,z),

--- a/src/models/Activity/NRTL/NRTL.jl
+++ b/src/models/Activity/NRTL/NRTL.jl
@@ -27,16 +27,16 @@ export NRTL
     reference_state = nothing)
 
 ## Input parameters
-- `a`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Interaction Parameter
-- `b`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Interaction Parameter
-- `c`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Interaction Parameter
-- `Mw`: Single Parameter (`Float64`) (Optional) - Molecular Weight `[g/mol]`
+- `a`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Parameter
+- `b`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Parameter
+- `c`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Parameter
+- `Mw`: Single Parameter (`Float64`) (Optional) - Molecular Weight `[g·mol⁻¹]`
 
 ## Input models
 - `puremodel`: model to calculate pure pressure-dependent properties
 
 ## Description
-NRTL (Non Random Two Fluid) activity model:
+NRTL (Non Random Two Liquids) activity model:
 ```
 Gᴱ = nRT∑[xᵢ(∑τⱼᵢGⱼᵢxⱼ)/(∑Gⱼᵢxⱼ)]
 Gᵢⱼ exp(-cᵢⱼτᵢⱼ)

--- a/src/models/Activity/UNIQUAC/UNIQUAC.jl
+++ b/src/models/Activity/UNIQUAC/UNIQUAC.jl
@@ -29,10 +29,10 @@ export UNIQUAC
 
 ## Input parameters
 - `a`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Energy Parameter
-- `r`: Single Parameter (`Float64`)  - Normalized Van der Vals volume
+- `r`: Single Parameter (`Float64`)  - Normalized Van der Waals volume
 - `q`: Single Parameter (`Float64`) - Normalized Surface Area
 - `q_p`: Single Parameter (`Float64`) - Modified Normalized Surface Area 
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 
 
 ## Input models

--- a/src/models/Activity/Wilson/Wilson.jl
+++ b/src/models/Activity/Wilson/Wilson.jl
@@ -30,15 +30,15 @@ export Wilson
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `acentricfactor`: Single Parameter (`Float64`) - Acentric Factor
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `g`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Interaction Parameter
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
+- `g`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Parameter
 
 ## model parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
 - `ZRA`: Single Parameter (`Float64`) - Rackett compresibility factor
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `g`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Interaction Parameter
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
+- `g`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Parameter
 
 ## Input models
 - `puremodel`: model to calculate pure pressure-dependent properties

--- a/src/models/Activity/Wilson/variants/tcPRWilsonRes.jl
+++ b/src/models/Activity/Wilson/variants/tcPRWilsonRes.jl
@@ -22,7 +22,7 @@ export tcPRWilsonRes
     reference_state = nothing)
 
 ## Input parameters
-- `g`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Interaction Parameter
+- `g`: Pair Parameter (`Float64`, asymetrical, defaults to `0`) - Binary Interaction Parameter
 - `v`: Single Parameter (optional) (`Float64`) - individual volumes.
 
 ## Input models

--- a/src/models/Activity/equations.jl
+++ b/src/models/Activity/equations.jl
@@ -208,11 +208,11 @@ function __tpflash_cache_model(model::ActivityModel,p,T,z,equilibrium)
     PTFlashWrapper(compmodel,p,T,equilibrium)
 end
 
-#LLE point. it does not require an imput concentration, because it assumes that activities are pressure-independent.
+#LLE point. it does not require an input concentration, because it assumes that activities are pressure-independent.
 """
     LLE(model::ActivityModel, T; v0=nothing)
 
-Calculates the Liquid-Liquid equilibrium compositions at a given temperature.
+Calculates the Liquid-Liquid equilibrium compositions at a given temperature `T`.
 
 Returns a tuple, containing:
 - Liquid composition `x₁`

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -39,7 +39,7 @@ There are three available representations for the fluid model:
 - Activity models, consisting of a liquid activity and a model for the fluid. The fluid model can be a Helmholtz-based model, or another `CompositeModel` containing correlations.
 When the solid field is specified, some properties (like `volume`) start taking in account the solid phase in their calculations. Optionally, there are other models that provide specific correlations for SLE equilibria (like `SolidHfus`).
 
-The solid model is optional and does not impact VLE (and LLE) calculations. Rhere are two available representations for the solid model:
+The solid model is optional and does not impact VLE (and LLE) calculations. There are two available representations for the solid model:
 - a Helmholtz-based EoS, can be used to calculate both melting/sublimation and solubilities.
 - Chemical Potential models, can be used for solubilities.
 

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -37,9 +37,9 @@ There are three available representations for the fluid model:
 - A Helmholtz-based EoS.
 - Fluid Correlations, consisting in a gas model, a correlation for obtaining the saturation pressure, and a liquid model. Both gas and liquid models can optionally be Helmholtz models too, but correlations for saturated liquid and vapour are also allowed.
 - Activity models, consisting of a liquid activity and a model for the fluid. The fluid model can be a Helmholtz-based model, or another `CompositeModel` containing correlations.
-When the solid field is specified, some properties (like `volume`) start taking in account the solid phase in their calculations. Optionally, there are other models that provide specific correlations for SLE equilibria (like `SolidHfus`)
+When the solid field is specified, some properties (like `volume`) start taking in account the solid phase in their calculations. Optionally, there are other models that provide specific correlations for SLE equilibria (like `SolidHfus`).
 
-The solid model is optional and does not impact VLE (and LLE) calculations. there are two available representations for the solid model
+The solid model is optional and does not impact VLE (and LLE) calculations. Rhere are two available representations for the solid model:
 - a Helmholtz-based EoS, can be used to calculate both melting/sublimation and solubilities.
 - Chemical Potential models, can be used for solubilities.
 
@@ -96,7 +96,7 @@ CompositeModel
 """
     RestrictedEquilibriaModel <: EoSModel
 
-Abstract type of models that implement simplifications over the equality of chemical potentials approach for phase equilibria. subtypes of `RestrictedEquilibriaModel` are the `GammaPhi` (activity + gas), `FluidCorrelation` (for fluid phase change and volume correlations) and `SolidCorrelation` (for solid phase change and solid volume correlations)
+Abstract type of models that implement simplifications over the equality of chemical potentials approach for phase equilibria. Subtypes of `RestrictedEquilibriaModel` are the `GammaPhi` (activity + gas), `FluidCorrelation` (for fluid phase change and volume correlations) and `SolidCorrelation` (for solid phase change and solid volume correlations).
 """
 abstract type RestrictedEquilibriaModel <: EoSModel end
 

--- a/src/models/CompositeModel/GammaPhi.jl
+++ b/src/models/CompositeModel/GammaPhi.jl
@@ -1,7 +1,7 @@
 """
     GammaPhi{γ,Φ} <: RestrictedEquilibriaModel
 
-wrapper struct to signal that a `CompositeModel` uses an activity model in conjunction with a fluid.
+Wrapper struct to signal that a `CompositeModel` uses an activity model in conjunction with a fluid.
 """
 struct GammaPhi{γ,Φ} <: RestrictedEquilibriaModel
     components::Vector{String}

--- a/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/COSTALD/costald.jl
@@ -15,12 +15,12 @@ end
 ## Input parameters
 
 - `Tc`: Single Parameter (Float64) - Critical Temperature `[K]`
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
 - `acentricfactor`: Single Parameter (`Float64`) - Acentric Factor
 
 ## Description
 
-COSTALD Equation of State for saturated liquids. it is independent of the pressure.
+COSTALD Equation of State for saturated liquids. It is independent of the pressure.
 
 ## Model Construction Examples
 ```julia

--- a/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
+++ b/src/models/CompositeModel/LiquidVolumeModel/Rackett/RackettLiquid.jl
@@ -16,19 +16,19 @@ end
 
 ## Input parameters
 
-- `Tc`: Single Parameter (Float64) - Critical Temperature [K]
-- `Pc`: Single Parameter (Float64) - Critical Pressure [Pa]
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
+- `Tc`: Single Parameter (Float64) - Critical Temperature `[K]`
+- `Pc`: Single Parameter (Float64) - Critical Pressure `[Pa]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
 
 ## Model Parameters
 
-- `Tc`: Single Parameter (Float64) - Critical Temperature [K]
+- `Tc`: Single Parameter (Float64) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (Float64) - Critical Pressure [Pa]
 - `Zc`: Single Parameter (Float64) - Critical Compressibility Factor
 
 ## Description
 
-Rackett Equation of State for saturated liquids. it is independent of the pressure.
+Rackett Equation of State for saturated liquids. It is independent of the pressure.
 ```
 Tr = T/Tc
 V = (R̄Tc/Pc)Zc^(1+(1-Tr)^(2/7))

--- a/src/models/CompositeModel/SaturationModel/SaturationModel.jl
+++ b/src/models/CompositeModel/SaturationModel/SaturationModel.jl
@@ -8,7 +8,7 @@ abstract type SaturationModel <: EoSModel end
 """
     SaturationCorrelation <: SaturationMethod
 
-saturation method used for dispatch on saturation correlations.
+Saturation method used for dispatch on saturation correlations.
 """
 struct SaturationCorrelation <: SaturationMethod end
 

--- a/src/models/CompositeModel/SolidCorrelation.jl
+++ b/src/models/CompositeModel/SolidCorrelation.jl
@@ -1,7 +1,7 @@
 """
     SolidCorrelation{P,M,L} <: RestrictedEquilibriaModel
 
-wrapper struct to signal that a `CompositeModel` uses solid correlations for the phase volume, melting and sublimation
+Wrapper struct to signal that a `CompositeModel` uses solid correlations for the phase volume, melting and sublimation.
 """
 struct SolidCorrelation{P,M,L} <: RestrictedEquilibriaModel
     components::Vector{String}

--- a/src/models/CompositeModel/SolidModel/SolidHfus.jl
+++ b/src/models/CompositeModel/SolidModel/SolidHfus.jl
@@ -17,9 +17,9 @@ end
 
 ## Parameters
 
-- `Hfus`: Single Parameter (`Float64`) - Enthalpy of Fusion at 1 bar `[J/mol]`
+- `Hfus`: Single Parameter (`Float64`) - Enthalpy of Fusion at 1 bar `[J·mol⁻¹]`
 - `Tm`: Single Parameter (`Float64`) - Melting Temperature `[K]`
-- `CpSL`: Single Parameter (`Float64`) (optional) - Heat Capacity of the Solid-Liquid Phase Transition `[J/mol/K]`
+- `CpSL`: Single Parameter (`Float64`) (optional) - Heat Capacity of the Solid-Liquid Phase Transition `[J·mol⁻¹·K⁻¹]`
 
 ## Description
 

--- a/src/models/CompositeModel/SolidModel/SolidKs.jl
+++ b/src/models/CompositeModel/SolidModel/SolidKs.jl
@@ -17,9 +17,9 @@ end
 
 ## Parameters
 
-- `Hfus`: Single Parameter (`Float64`) - Enthalpy of Fusion at 1 bar `[J/mol]`
+- `Hfus`: Single Parameter (`Float64`) - Enthalpy of Fusion at 1 bar `[J·mol⁻¹]`
 - `Tm`: Single Parameter (`Float64`) - Melting Temperature `[K]`
-- `CpSL`: Single Parameter (`Float64`) - Heat Capacity of the Solid-Liquid Phase Transition `[J/mol/K]`
+- `CpSL`: Single Parameter (`Float64`) - Heat Capacity of the Solid-Liquid Phase Transition `[J·mol⁻¹·K⁻¹]`
 
 ## Description
 
@@ -50,7 +50,7 @@ export SolidKs
 """
     sle_solubility(model::CompositeModel, p, T, z; solute)
 
-Calculates the solubility of each component within a solution of the other components, at a given temperature and composition.
+Calculates the solubility of each component within a solution of the other components, at a given temperature `T` and composition `z`.
 Returns a matrix containing the composition of the SLE phase boundary for each component. If `solute` is specified, returns only the solubility of the specified component.
 
 Can only function when solid and fluid models are specified within a CompositeModel.

--- a/src/models/ECS/ECS.jl
+++ b/src/models/ECS/ECS.jl
@@ -15,7 +15,7 @@ end
 ## Input Models
 
 - `shape_model`: shape model
-- `shape_ref`:  shape reference. is the same type of EoS that `shape_model`
+- `shape_ref`:  shape reference. Is the same type of EoS that `shape_model`.
 - `model_ref`: Reference model
 
 ## Description

--- a/src/models/Electrolytes/equations.jl
+++ b/src/models/Electrolytes/equations.jl
@@ -1,6 +1,6 @@
 """
     salt_stoichiometry(model::ElectrolyteModel,salts)
-Obtain the stoichiometry matrix of `salts` made up of ions stored in the `model`. This will also check that the salt is electroneutral and that all ions are involved in the salts.
+Obtains the stoichiometry matrix of `salts` made up of ions stored in the `model`. This will also check that the salt is electroneutral and that all ions are involved in the salts.
 """
 function salt_stoichiometry(model::ElectrolyteModel,salts)
     iions = model.charge.!=0

--- a/src/models/EmpiricHelmholtz/LJRef/LJRef.jl
+++ b/src/models/EmpiricHelmholtz/LJRef/LJRef.jl
@@ -24,13 +24,14 @@ export LJRef
 - `sigma`: Single Parameter (`Float64`) - particle size `[Å]`
 - `epsilon`: Single Parameter (`Float64`) - dispersion energy `[K]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `k`: Pair Parameter (`Float64`) (optional) - `sigma` mixing coefficient
+- `k`: Pair Parameter (`Float64`) (optional)
+- `sigma` mixing coefficient
 ## Model Parameters
 - `sigma`: Pair Parameter (`Float64`) - particle size `[m]`
 - `epsilon`: Pair Parameter (`Float64`) - dispersion energy `[K]`
 - `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
 ## Description
-Lennard-Jones Reference equation of state. valid from 0.5 < T/Tc < 7 and pressures up to p/pc = 500.
+Lennard-Jones Reference equation of state. Valid from 0.5 < T/Tc < 7 and pressures up to p/pc = 500.
 ```
 σᵢⱼ = (σᵢ + σⱼ)/2
 ϵᵢⱼ = (1-kᵢⱼ)√(ϵⱼϵⱼ)

--- a/src/models/EmpiricHelmholtz/LKP/LKP.jl
+++ b/src/models/EmpiricHelmholtz/LKP/LKP.jl
@@ -19,16 +19,16 @@ abstract type LKPModel <: EmpiricHelmholtzModel end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m^3]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m³]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `acentricfactor`: Single Parameter (`Float64`) - Acentric Factor (no units)
-- `k`: Pair Parameter (`Float64`) (optional) - binary interaction parameter (no units)
+- `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Parameter (no units)
 
 ## Input models
 - `idealmodel`: Ideal Model
 
 ## Description
-Lee-Kesler-Plöker equation of state. corresponding states using interpolation between a simple, spherical fluid (methane, `∅`)  and a reference fluid (n-octane, `ref`):
+Lee-Kesler-Plöker equation of state. Corresponding states using interpolation between a simple, spherical fluid (methane, `∅`)  and a reference fluid (n-octane, `ref`):
 ```
 αᵣ = (1 - ωᵣ)*αᵣ(δr,τ,params(∅)) + ωᵣ*αᵣ(δr,τ,params(ref))
 τ = Tr/T

--- a/src/models/EmpiricHelmholtz/LKP/variants/LKPSJT.jl
+++ b/src/models/EmpiricHelmholtz/LKP/variants/LKPSJT.jl
@@ -50,10 +50,10 @@ end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m^3]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m³]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `acentricfactor`: Single Parameter (`Float64`) - Acentric Factor (no units)
-- `k`: Pair Parameter (`Float64`) (optional) - binary interaction parameter (no units)
+- `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Parameter (no units)
 
 ## Input models
 - `idealmodel`: Ideal Model

--- a/src/models/EmpiricHelmholtz/LKP/variants/LKPmod.jl
+++ b/src/models/EmpiricHelmholtz/LKP/variants/LKPmod.jl
@@ -11,16 +11,16 @@ abstract type LKPmodModel <: LKPModel end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m^3]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m³]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `acentricfactor`: Single Parameter (`Float64`) - Acentric Factor (no units)
-- `k`: Pair Parameter (`Float64`) (optional) - binary interaction parameter (no units)
+- `k`: Pair Parameter (`Float64`) (optional) - Binary Interaction Parameter (no units)
 
 ## Input models
 - `idealmodel`: Ideal Model
 
 ## Description
-Lee-Kesler-Plöker equation of state. corresponding states using interpolation between a simple, spherical fluid (methane, `∅`)  and a reference fluid (n-octane, `ref`):
+Lee-Kesler-Plöker equation of state. Corresponding states using interpolation between a simple, spherical fluid (methane, `∅`)  and a reference fluid (n-octane, `ref`):
 
 Coefficients of the original EoS were modified in [2] guarantee a correct behaviour of the EoS in the liquid phase.
 ```

--- a/src/models/EmpiricHelmholtz/MultiFluid/departure/EmpiricDeparture.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/departure/EmpiricDeparture.jl
@@ -37,7 +37,7 @@ end
 
 Creates a departure model for use in a `MultiFluid` model with `EmpiricDeparture`.
 
-If `data` is a `String` and starts with `{` or `[`, it will be recognized as JSON text. the text will be parsed as a file location otherwise. 
+If `data` is a `String` and starts with `{` or `[`, it will be recognized as JSON text. The text will be parsed as a file location otherwise. 
 You can pass a `Dict` or `NamedTuple` if you want to skip the JSON parsing.
 
 ## Examples

--- a/src/models/EmpiricHelmholtz/MultiFluid/departure/GEDeparture.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/departure/GEDeparture.jl
@@ -42,11 +42,11 @@ GEDeparture <: MultiFluidDepartureModel
 
 ## Input parameters
 none
-- `k1`: Pair Parameter (`Float64`) - binary, T-dependent interaction parameter `[K^-1]`
+- `k1`: Pair Parameter (`Float64`) - binary, T-dependent interaction parameter `[K⁻¹]`
 ## Model parameters
-- `vref`: Single Parameter (`Float64`, calculated) - Reference pure molar volume `[m3/mol]`
+- `vref`: Single Parameter (`Float64`, calculated) - Reference pure molar volume `[m³·mol⁻¹]`
 ## Input models
-- `activity`: activity model
+- `activity`: activity coefficient model
 
 ## Description
 

--- a/src/models/EmpiricHelmholtz/MultiFluid/departure/QuadraticDeparture.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/departure/QuadraticDeparture.jl
@@ -12,8 +12,8 @@ end
     verbose = false)
 
 ## Input parameters
-- `k0`: Pair Parameter (`Float64`) - binary interaction parameter  (no units)
-- `k1`: Pair Parameter (`Float64`) - binary, T-dependent interaction parameter `[K^-1]`
+- `k0`: Pair Parameter (`Float64`) - Binary Interaction Parameter  (no units)
+- `k1`: Pair Parameter (`Float64`) - Binary, T-dependent, Interaction Parameter `[K⁻¹]`
 
 ## Description
 

--- a/src/models/EmpiricHelmholtz/MultiFluid/mixing/Asymmetric.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/mixing/Asymmetric.jl
@@ -144,7 +144,7 @@ end
 """
     mixing_rule_asymmetric(op, op_asym, x, p, A, A_asym)
 
-returns an efficient implementation of:
+Returns an efficient implementation of:
 ` sum(A[i,j] * x[i] * x[j] * op(p[i],p[j]) * op_asym(x[i],x[j],A_asym[i,j])) for i = 1:n , j = 1:n)`
 where `op(p[i],p[j]) == op(p[j],p[i])` , op_asym doesn't follow this symmetry.
 

--- a/src/models/EmpiricHelmholtz/MultiFluid/multifluid.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/multifluid.jl
@@ -55,7 +55,7 @@ Rgas(model::MultiFluid) = model.Rgas
 - JSON data (CoolProp and teqp format)
 
 ## Input models
-- `idealmodel`: Ideal Model. if it is `nothing`, then it will parse the ideal model from the input JSON.
+- `idealmodel`: Ideal Model. If it is `nothing`, then it will parse the ideal model from the input JSON.
 - `mixing`: mixing model for temperature and volume.
 - `departure`: departure model
 

--- a/src/models/EmpiricHelmholtz/SingleFluid/variants/Ammonia2023.jl
+++ b/src/models/EmpiricHelmholtz/SingleFluid/variants/Ammonia2023.jl
@@ -19,7 +19,7 @@ aʳ₃(δ,τ)  = ∑nᵢexp(-ηᵢ(δ - εᵢ)^2 - βᵢ(τ - γᵢ)^2)δ^(dᵢ)
 aʳ₃(δ,τ)  = ∑nᵢexp(-ηᵢ(δ - εᵢ)^2 - 1/(βᵢ*(τ -γᵢ)^2 + bᵢ))δ^(dᵢ)τ^(tᵢ), i ∈ 19:20
 
 ```
-parameters  `n⁰`,`γ⁰`,`n`,`t`,`d`,`c`,`η`,`β`,`γ`,`ε` where obtained via fitting.
+Parameters  `n⁰`,`γ⁰`,`n`,`t`,`d`,`c`,`η`,`β`,`γ`,`ε` where obtained via fitting.
 
 ## References
 1. Gao, K., Wu, J., Bell, I. H., Harvey, A. H., & Lemmon, E. W. (2023). A reference equation of state with an associating term for the thermodynamic properties of ammonia. Journal of Physical and Chemical Reference Data, 52(1), 013102. [doi:10.1063/5.0128269](https://doi.org/10.1063/5.0128269)

--- a/src/models/cubic/PR/PR.jl
+++ b/src/models/cubic/PR/PR.jl
@@ -31,14 +31,14 @@ end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `a`: Pair Parameter (`Float64`)
 - `b`: Pair Parameter (`Float64`)
 ## Input models

--- a/src/models/cubic/PR/variants/EPPR78.jl
+++ b/src/models/cubic/PR/variants/EPPR78.jl
@@ -56,7 +56,7 @@ HC=-C-
     translation_userlocations = String[],
     reference_state = nothing,
     verbose = false)
-Enhanced Predictive Peng Robinson equation of state. it uses the following models:
+Enhanced Predictive Peng Robinson equation of state. It uses the following models:
 - Translation Model: [`NoTranslation`](@ref)
 - Alpha Model: [`PR78Alpha`](@ref)
 - Mixing Rule Model: [`PPR78Rule`](@ref)

--- a/src/models/cubic/PR/variants/PR78.jl
+++ b/src/models/cubic/PR/variants/PR78.jl
@@ -13,7 +13,7 @@
     reference_state = nothing,
     verbose = false)
 
-Peng Robinson (1978) equation of state. it uses the following models:
+Peng Robinson (1978) equation of state. It uses the following models:
 - Translation Model: [`NoTranslation`](@ref)
 - Alpha Model: [`PR78Alpha`](@ref)
 - Mixing Rule Model: [`vdW1fRule`](@ref)

--- a/src/models/cubic/PR/variants/QCPR.jl
+++ b/src/models/cubic/PR/variants/QCPR.jl
@@ -10,7 +10,7 @@
         reference_state = nothing,
         verbose = false)
 
-Quantum-corrected Peng Robinson equation of state. it uses the following models:
+Quantum-corrected Peng Robinson equation of state. It uses the following models:
 - Translation Model: [`ConstantTranslation`](@ref)
 - Alpha Model: [`TwuAlpha`](@ref)
 - Mixing Rule Model: [`QCPRRule`](@ref)

--- a/src/models/cubic/PR/variants/UMRPR.jl
+++ b/src/models/cubic/PR/variants/UMRPR.jl
@@ -11,7 +11,7 @@
     reference_state = nothing,
     verbose = false)
 
-Universal Mixing Rule Peng Robinson equation of state. it uses the following models:
+Universal Mixing Rule Peng Robinson equation of state. It uses the following models:
 - Translation Model: [`MTTranslation`](@ref)
 - Alpha Model: [`MTAlpha`](@ref)
 - Mixing Rule Model: [`UMRRule`](@ref) with [`UNIFAC`](@ref) activity

--- a/src/models/cubic/PR/variants/VTPR.jl
+++ b/src/models/cubic/PR/variants/VTPR.jl
@@ -11,7 +11,7 @@
     reference_state = nothing,
     verbose = false)
 
-Volume-translated Peng Robinson equation of state. it uses the following models:
+Volume-translated Peng Robinson equation of state. It uses the following models:
 - Translation Model: [`RackettTranslation`](@ref)
 - Alpha Model: [`TwuAlpha`](@ref)
 - Mixing Rule Model: [`VTPRRule`](@ref) with [`VTPRUNIFAC`](@ref) activity

--- a/src/models/cubic/PR/variants/cPR.jl
+++ b/src/models/cubic/PR/variants/cPR.jl
@@ -10,7 +10,7 @@
     reference_state = nothing,
     verbose = false)
 
-consistent Peng Robinson equation of state. it uses the following models:
+Consistent Peng Robinson equation of state. It uses the following models:
 - Translation Model: [`NoTranslation`](@ref)
 - Alpha Model: [`TwuAlpha`](@ref)
 - Mixing Rule Model: [`vdW1fRule`](@ref)

--- a/src/models/cubic/PR/variants/tcPR.jl
+++ b/src/models/cubic/PR/variants/tcPR.jl
@@ -12,7 +12,7 @@
     estimate_alpha = true,
     estimate_translation = true)
 
-translated and consistent Peng Robinson equation of state. it uses the following models:
+Translated and consistent Peng Robinson equation of state. It uses the following models:
 - Translation Model: [`ConstantTranslation`](@ref)
 - Alpha Model: [`TwuAlpha`](@ref)
 - Mixing Rule Model: [`vdW1fRule`](@ref)

--- a/src/models/cubic/PR/variants/tcPRW.jl
+++ b/src/models/cubic/PR/variants/tcPRW.jl
@@ -10,7 +10,7 @@
     reference_state = nothing,
     verbose = false)
 
-translated and consistent Peng Robinson equation of state,with an gE mixing rule. it uses the following models:
+Translated and consistent Peng Robinson equation of state, with an gE mixing rule. It uses the following models:
 - Translation Model: [`ConstantTranslation`](@ref)
 - Alpha Model: [`TwuAlpha`](@ref)
 - Mixing Rule Model: [`gErRule`](@ref)

--- a/src/models/cubic/RK/RK.jl
+++ b/src/models/cubic/RK/RK.jl
@@ -32,14 +32,14 @@ export RK
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `a`: Pair Parameter (`Float64`)
 - `b`: Pair Parameter (`Float64`)
 

--- a/src/models/cubic/RKPR/RKPR.jl
+++ b/src/models/cubic/RKPR/RKPR.jl
@@ -53,17 +53,17 @@ export RKPR
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m3/mol]`
+- `Vc`: Single Parameter (`Float64`) (optional) - Critical Volume `[m³·mol⁻¹]`
 - `delta`: Single Parameter (`Float64`) (optional) - constant parameter (no units)
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m3/mol]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `a`: Pair Parameter (`Float64`)
 - `b`: Pair Parameter (`Float64`)
 - `delta`: Single Parameter (`Float64`) - constant parameter (no units)

--- a/src/models/cubic/alphas/BM.jl
+++ b/src/models/cubic/alphas/BM.jl
@@ -14,13 +14,12 @@ export BMAlpha
 
 ## Input Parameters
 
-
 - `acentricfactor`: Single Parameter (`Float64`)
 
 ## Description
 
-Boston Mathias Cubic alpha `(α(T))` model. Identical to a soave model when Tr <= 1, while having the correct behaviour at supercritical temperatures (via extrapolation at the critical point.)
-```
+Boston Mathias Cubic alpha `(α(T))` model. Identical to a Soave model when Tr <= 1, while having the correct behaviour at supercritical temperatures (via extrapolation at the critical point).
+```julia
 if Trᵢ > 1
     αᵢ = (exp((1-2/(2+mᵢ))*(1-Trᵢ^(1+mᵢ/2))))^2
 else

--- a/src/models/cubic/alphas/alphas.jl
+++ b/src/models/cubic/alphas/alphas.jl
@@ -1,7 +1,7 @@
 """
     α_function(model::CubicModel,V,T,z,αmodel::AlphaModel)
 
-Interface function used in cubic models. it should return a vector of αᵢ(T).
+Interface function used in cubic models. It should return a vector of αᵢ(T).
 
 ## Example:
 

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -24,8 +24,8 @@ const ONLY_ACENTRICFACTOR = vcat(IGNORE_HEADERS,["Tc", "Pc", "Vc"])
 """
     ab_premixing(model,mixing,kij = nothing,lij = nothing)
 
-given a model::CubicModel, that has `a::PairParam`, `b::PairParam`, a mixing::MixingRule and `kij`,`lij` matrices, `ab_premixing` will perform an implace calculation
-to obtain the values of `a` and `b`, containing values aᵢⱼ and bᵢⱼ. by default, it performs the van der Wals One-Fluid mixing rule. that is:
+Given a model::CubicModel, that has `a::PairParam`, `b::PairParam`, a mixing::MixingRule and `kij`,`lij` matrices, `ab_premixing` will perform an implace calculation
+to obtain the values of `a` and `b`, containing values aᵢⱼ and bᵢⱼ. by default, it performs the van der Waals One-Fluid mixing rule. that is:
 ```
 aᵢⱼ = sqrt(aᵢ*aⱼ)*(1-kᵢⱼ)
 bᵢⱼ = (bᵢ + bⱼ)/2

--- a/src/models/cubic/translation/ConstantTranslation.jl
+++ b/src/models/cubic/translation/ConstantTranslation.jl
@@ -13,7 +13,7 @@ end
     verbose::Bool=false)
 ## Input Parameters
 
-- `v_shift`: Single Parameter (`Float64`) - Volume shift `[m³/mol]`
+- `v_shift`: Single Parameter (`Float64`) - Volume shift `[m³·mol⁻¹]`
 
 ## Description
 Constant Translation model for cubics:

--- a/src/models/cubic/translation/NoTranslation.jl
+++ b/src/models/cubic/translation/NoTranslation.jl
@@ -11,7 +11,7 @@ None
 
 ## Description
 
-Default volume translation model for cubic models. it performs no translation:
+Default volume translation model for cubic models. It performs no translation:
 
 ```
 V = V₀ + mixing_rule(cᵢ)

--- a/src/models/cubic/translation/Peneloux.jl
+++ b/src/models/cubic/translation/Peneloux.jl
@@ -17,12 +17,12 @@ end
 
 ## Input Parameters
 
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
 
 ## Model Parameters
 
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
-- `v_shift`: Single Parameter (`Float64`) - Volume shift `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
+- `v_shift`: Single Parameter (`Float64`) - Volume shift `[m³·mol⁻¹]`
 
 
 ## Description

--- a/src/models/cubic/translation/Rackett.jl
+++ b/src/models/cubic/translation/Rackett.jl
@@ -16,12 +16,12 @@ end
 
 ## Input Parameters
 
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
 
 ## Model Parameters
 
-- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³/mol]`
-- `v_shift`: Single Parameter (`Float64`) - Volume shift `[m³/mol]`
+- `Vc`: Single Parameter (`Float64`) - Critical Volume `[m³·mol⁻¹]`
+- `v_shift`: Single Parameter (`Float64`) - Volume shift `[m³·mol⁻¹]`
 
 ## Description
 

--- a/src/models/cubic/translation/translation.jl
+++ b/src/models/cubic/translation/translation.jl
@@ -1,7 +1,7 @@
 """
     translation(model::CubicModel,V,T,z,translation_model::TranslationModel)  
 
-Interface function used in cubic models. it should return a vector of cᵢ. such as `Ṽ = V + mixing(c,z)`
+Interface function used in cubic models. It should return a vector of cᵢ. Such as `Ṽ = V + mixing(c,z)`
 
 ## Example:
 

--- a/src/models/cubic/vdW/variants/Berthelot.jl
+++ b/src/models/cubic/vdW/variants/Berthelot.jl
@@ -51,8 +51,8 @@ export Berthelot
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
-- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m³·mol⁻¹]`
 - `k`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
@@ -60,8 +60,8 @@ export Berthelot
 - `b`: Pair Parameter (`Float64`)
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m³·mol⁻¹]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 
 
 ## Input models
@@ -73,7 +73,7 @@ export Berthelot
 
 ## Description
 
-Berthelot Equation of state. it uses the Volume-Pressure Based mixing rules, that is:
+Berthelot Equation of state. It uses the Volume-Pressure Based mixing rules, that is:
 ```
 a = 8*Pc*Vc^2
 b = Vc/3

--- a/src/models/cubic/vdW/variants/Clausius.jl
+++ b/src/models/cubic/vdW/variants/Clausius.jl
@@ -31,16 +31,16 @@ end
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m³·mol⁻¹]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m^3/mol]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Vc`: Single Parameter (`Float64`) - Molar Volume `[m³·mol⁻¹]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `a`: Pair Parameter (`Float64`)
 - `b`: Pair Parameter (`Float64`)
 

--- a/src/models/cubic/vdW/vdW.jl
+++ b/src/models/cubic/vdW/vdW.jl
@@ -33,14 +33,14 @@ export vdW
 ## Input parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `k`: Pair Parameter (`Float64`) (optional)
 - `l`: Pair Parameter (`Float64`) (optional)
 
 ## Model Parameters
 - `Tc`: Single Parameter (`Float64`) - Critical Temperature `[K]`
 - `Pc`: Single Parameter (`Float64`) - Critical Pressure `[Pa]`
-- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g/mol]`
+- `Mw`: Single Parameter (`Float64`) - Molecular Weight `[g·mol⁻¹]`
 - `a`: Pair Parameter (`Float64`)
 - `b`: Pair Parameter (`Float64`)
 
@@ -53,7 +53,7 @@ export vdW
 
 ## Description
 
-van der Wals Equation of state.
+van der Waals Equation of state.
 
 ```
 P = RT/(V-Nb) + a•α(T)/V²

--- a/src/modules/solvers/ad.jl
+++ b/src/modules/solvers/ad.jl
@@ -57,7 +57,7 @@ end
 """
     f∂f(f,x)
 
-returns f and ∂f/∂x evaluated in `x`, using `ForwardDiff.jl`, `DiffResults.jl` and `StaticArrays.jl` to calculate everything in one pass.
+Returns f and ∂f/∂x evaluated in `x`, using `ForwardDiff.jl`, `DiffResults.jl` and `StaticArrays.jl` to calculate everything in one pass.
 """
 @inline function f∂f(f::F, x::R) where {F,R<:Real}
     T = typeof(ForwardDiff.Tag(f, R))
@@ -71,7 +71,7 @@ f∂f(f::F) where F = Base.Fix1(f∂f,f)
 """
     f∂f∂2f(f,x)
 
-returns f,∂f/∂x,and ∂²f/∂²x and evaluated in `x`, using `ForwardDiff.jl`, `DiffResults.jl` and `StaticArrays.jl` to calculate everything in one pass.
+Returns f,∂f/∂x,and ∂²f/∂²x and evaluated in `x`, using `ForwardDiff.jl`, `DiffResults.jl` and `StaticArrays.jl` to calculate everything in one pass.
 """
 @inline function f∂f∂2f(f::F,x::R) where {F,R<:Real}
     T = typeof(ForwardDiff.Tag(f, R))
@@ -88,7 +88,7 @@ f∂f∂2f(f::F) where F = Base.Fix1(f∂f∂2f,f)
 """
     fgradf2(f,x1,x2)
 
-returns f and ∇f(x),using `ForwardDiff.jl`
+Returns f and ∇f(x),using `ForwardDiff.jl`
 """
 function fgradf2(f::F,x1::R1,x2::R2) where{F,R1<:Real,R2<:Real}
     y1,y2 = promote(x1,x2)
@@ -253,7 +253,7 @@ end
 """
     primalval(x::Real)
 
-returns the primal value of a value. strips all duals from `ForwardDiff`. useful in debugging:
+Returns the primal value of a value. Strips all duals from `ForwardDiff`. Useful in debugging:
 
 ## Example
 ```julia

--- a/src/modules/solvers/integral.jl
+++ b/src/modules/solvers/integral.jl
@@ -70,7 +70,7 @@ const laguerre10_w = (0.30844111576502015, 0.40111992915527356, 0.21806828761180
 """
     laguerre5(f,r = 1, a = 0)
 
-Performs a 5-point translated gauss-laguerre integration of the form:
+Performs a 5-point translated Gauss-Laguerre integration of the form:
 
 ```
 ∫exp(-ry)f(y) dy,    y ∈ (a,∞)
@@ -83,7 +83,7 @@ end
 """
     laguerre5(f,r = 1, a = 0)
 
-Performs a 10-point translated gauss-laguerre integration of the form:
+Performs a 10-point translated Gauss-Laguerre integration of the form:
 
 ```
 ∫exp(-ry)f(y) dy,    y ∈ (a,∞)

--- a/src/modules/solvers/poly.jl
+++ b/src/modules/solvers/poly.jl
@@ -71,7 +71,7 @@ end
     real_roots3(pol::NTuple{4,T}) where {T<:Real}
 
 Given a cubic real polynom of the form `pol[1] + pol[2]*x + pol[3]*x^2 + pol[4]*x^3`,
-return `(n, zl, zg)` where `n` is the number of real roots and:
+returns `(n, zl, zg)` where `n` is the number of real roots and:
 - if `n == 1`, `zl` and `zg` are equal to the only real root, the other two are complex.
 - if `n == 2`, `zl` is the single real root and `zg` is the double (degenerate) real root.
 - if `n == 3`, `zl` is the lowest real root and `zg` the greatest real root.
@@ -111,7 +111,7 @@ real_roots3(a,b,c,d) = real_roots3((a,b,c,d))
 """
     polyder(poly)
 
-returns the coefficients of the derivative of the polynomial.
+Returns the coefficients of the derivative of the polynomial.
 
 """
 function polyder(x::NTuple{N,T}) where {N,T}


### PR DESCRIPTION
Doc updates, Fixes issue #419. One thing that needs to be addressed in another PR because is non trivial to solve is that depends on where you look in the package, Helmholtz free energy naming varies between f and A. I know that there is not a unic naming convention for this variable but naming should be coherent throughout the package.