### PR TITLE
Add more control over specifying parameters in electrolyte eos

### DIFF
--- a/src/models/Electrolytes/base.jl
+++ b/src/models/Electrolytes/base.jl
@@ -37,8 +37,10 @@ function ESElectrolyte(solvents,ions;
     neutralmodel = pharmaPCSAFT,
     ionmodel = DH,
     RSPmodel = ConstRSP,
-    userlocations=String[],
-    ideal_userlocations=String[],
+    charges = String[],
+    ideal_userlocations = String[],
+    neutralmodel_userlocations = String[],
+    ionmodel_userlocations = String[],
     RSPmodel_userlocations = String[],
     assoc_options = AssocOptions(),
     verbose = false,
@@ -46,7 +48,7 @@ function ESElectrolyte(solvents,ions;
     components = deepcopy(ions)
     prepend!(components,solvents)
 
-    params = getparams(components, ["Electrolytes/properties/charges.csv"]; userlocations=userlocations, verbose=verbose)
+    params = getparams(components, ["Electrolytes/properties/charges.csv"]; userlocations=charges, verbose=verbose)
     charge = params["charge"].values
     #path0 = default_locations(neutralmodel)
     #remove unused datapaths
@@ -54,13 +56,13 @@ function ESElectrolyte(solvents,ions;
     init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
     init_RSP = @initmodel RSPmodel(solvents,ions,userlocations = RSPmodel_userlocations,verbose = verbose)
     if has_sites(neutralmodel)
-        init_neutralmodel = neutralmodel(components;userlocations,verbose,assoc_options)
+        init_neutralmodel = neutralmodel(components;userlocations=neutralmodel_userlocations,verbose,assoc_options)
     else
-        init_neutralmodel = neutralmodel(components;userlocations,verbose)
+        init_neutralmodel = neutralmodel(components;userlocations=neutralmodel_userlocations,verbose)
     end
 
     ionmodel_userlocations = userlocations
-    init_ionmodel = @initmodel ionmodel(solvents,ions;RSPmodel=init_RSP,userlocations = userlocations,verbose=verbose)
+    init_ionmodel = @initmodel ionmodel(solvents,ions;RSPmodel=init_RSP,userlocations=ionmodel_userlocations,verbose=verbose)
 
     components = init_neutralmodel.components
 

--- a/src/models/SAFT/PCSAFT/variants/ePCSAFT.jl
+++ b/src/models/SAFT/PCSAFT/variants/ePCSAFT.jl
@@ -51,23 +51,26 @@ function ePCSAFT(solvents,ions;
     neutralmodel = pharmaPCSAFT,
     ionmodel = hsdDH,
     RSPmodel = ConstRSP,
-    userlocations=String[], 
-    ideal_userlocations=String[],
+    charges = String[],
+    ideal_userlocations = String[],
+    neutralmodel_userlocations = String[],
+    ionmodel_userlocations = String[],
+    RSPmodel_userlocations = String[],
     assoc_options = AssocOptions(),
     verbose = false,
     reference_state = nothing)
     components = deepcopy(ions)
     prepend!(components,solvents)
 
-    params = getparams(format_components(components), ["Electrolytes/properties/charges.csv"]; userlocations=userlocations, verbose=verbose)
+    params = getparams(format_components(components), ["Electrolytes/properties/charges.csv"]; userlocations=charges, verbose=verbose)
     _charge = params["charge"]
     charge = _charge.values
 
     neutral_path = DB_PATH.*["/SAFT/PCSAFT","/SAFT/PCSAFT/ePCSAFT","/SAFT/PCSAFT/pharmaPCSAFT"]
 
     init_idealmodel = init_model(idealmodel,components,ideal_userlocations,verbose)
-    init_neutralmodel = neutralmodel(components;userlocations=append!(userlocations,neutral_path),verbose=verbose,assoc_options=assoc_options)
-    init_ionmodel = ionmodel(solvents,ions;RSPmodel=RSPmodel,userlocations=append!(userlocations,neutral_path),verbose=verbose)
+    init_neutralmodel = neutralmodel(components;userlocations=append!(neutralmodel_userlocations,neutral_path),verbose=verbose,assoc_options=assoc_options)
+    init_ionmodel = ionmodel(solvents,ions;RSPmodel=RSPmodel,userlocations=append!(ionmodel_userlocations,neutral_path),verbose=verbose)
 
 
     for i in ions

--- a/src/models/SAFT/SAFTVRMie/variants/SAFTVREMie.jl
+++ b/src/models/SAFT/SAFTVRMie/variants/SAFTVREMie.jl
@@ -45,8 +45,10 @@ function SAFTVREMie(solvents,ions;
     neutralmodel = SAFTVRMie,
     ionmodel = MSABorn,
     RSPmodel = Schreckenberg,
-    userlocations = String[], 
-    ideal_userlocations=String[],
+    charges = String[], 
+    ideal_userlocations = String[],
+    neutralmodel_userlocations = String[],
+    ionmodel_userlocations = String[],
     RSPmodel_userlocations = String[],
     assoc_options = AssocOptions(),
     reference_state = nothing,
@@ -54,7 +56,7 @@ function SAFTVREMie(solvents,ions;
 
     return ESElectrolyte(solvents,ions;
     idealmodel,neutralmodel,ionmodel,RSPmodel,
-    userlocations,ideal_userlocations,RSPmodel_userlocations,assoc_options,reference_state,verbose)
+    charges,ideal_userlocations,neutralmodel_userlocations,ionmodel_userlocations,RSPmodel_userlocations,assoc_options,reference_state,verbose)
 end
 
 export SAFTVREMie

--- a/src/models/SAFT/SAFTVRMie/variants/eSAFTVRMie.jl
+++ b/src/models/SAFT/SAFTVRMie/variants/eSAFTVRMie.jl
@@ -57,8 +57,10 @@ function eSAFTVRMie(solvents,ions;
     neutralmodel = SAFTVRMie15,
     ionmodel = DHBorn,
     RSPmodel = ZuoFurst,
-    userlocations = String[], 
-    ideal_userlocations=String[],
+    charges = String[], 
+    ideal_userlocations = String[],
+    neutralmodel_userlocations = String[],
+    ionmodel_userlocations = String[],
     RSPmodel_userlocations = String[],
     assoc_options = AssocOptions(),
     reference_state = nothing,
@@ -66,7 +68,7 @@ function eSAFTVRMie(solvents,ions;
 
     return ESElectrolyte(solvents,ions;
     idealmodel,neutralmodel,ionmodel,RSPmodel,
-    userlocations,ideal_userlocations,RSPmodel_userlocations,assoc_options,reference_state,verbose)
+    charges,ideal_userlocations,neutralmodel_userlocations,ionmodel_userlocations,RSPmodel_userlocations,assoc_options,reference_state,verbose)
 end
 
 export eSAFTVRMie

--- a/src/models/SAFT/SAFTgammaMie/variants/SAFTgammaEMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/variants/SAFTgammaEMie.jl
@@ -44,8 +44,10 @@ function SAFTgammaEMie(solvents,ions;
     neutralmodel = SAFTgammaMie,
     ionmodel = GCMSABorn,
     RSPmodel = Schreckenberg,
-    userlocations = String[], 
-    ideal_userlocations=String[],
+    charges = String[], 
+    ideal_userlocations = String[],
+    neutralmodel_userlocations = String[],
+    ionmodel_userlocations = String[],
     RSPmodel_userlocations = String[],
     assoc_options = AssocOptions(),
     reference_state = nothing,
@@ -53,7 +55,7 @@ function SAFTgammaEMie(solvents,ions;
 
     return ESElectrolyte(solvents,ions;
     idealmodel,neutralmodel,ionmodel,RSPmodel,
-    userlocations,ideal_userlocations,RSPmodel_userlocations,assoc_options,reference_state,verbose)
+    charges,ideal_userlocations,neutralmodel_userlocations,ionmodel_userlocations,RSPmodel_userlocations,assoc_options,reference_state,verbose)
     
 end
 


### PR DESCRIPTION
This PR should allow better custom specification of electrolyte model parameters. There are three sets of parameters that can be specified:
1. The charges of each species. @longemen3000 can users specify charges as an array in this set-up?
2. ideal_userlocations
3. neutralmodel_userlocations
4. ionmodel_userlocations
5. RSPmodel_userlocations
The only annoying part I can anticipate is that some parameters (like sigma) overlap between the ionmodel and neutralmodel. Users might need to specify them twice.