### PR TITLE
Faster `Property`/`Tproperty`

### DIFF
--- a/docs/src/properties/bulk.md
+++ b/docs/src/properties/bulk.md
@@ -102,6 +102,13 @@ Clapeyron.aqueous_activity
 Clapeyron.mixing
 ```
 
+## Isogibbs condition functions
+
+```@docs
+Clapeyron.edge_pressure
+Clapeyron.edge_temperature
+```
+
 ## Initial guess functions
 
 These methods are considered internal, they don't support `Symbolics.jl` or `Unitful.jl` overloads.

--- a/docs/src/properties/multi.md
+++ b/docs/src/properties/multi.md
@@ -29,6 +29,7 @@ Clapeyron.LLE
 Clapeyron.VLLE_pressure
 Clapeyron.VLLE_temperature
 Clapeyron.crit_mix
+Clapeyron.mechanical_critical_point
 Clapeyron.UCEP_mix
 Clapeyron.UCST_pressure
 Clapeyron.UCST_temperature

--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -978,16 +978,16 @@ end
 
 Given critical information and a temperature, extrapolate the liquid and vapor saturation volumes.
 """
-function critical_vsat_extrapolation(model,T,Tc,Vc)
+function critical_vsat_extrapolation(model,T,Tc,Vc,z = SA[1.0])
     if T > Tc
-        _0 = zero(Base.promote_eltype(model,T))
+        _0 = zero(Base.promote_eltype(model,T,z))
         nan = _0/_0
         return nan,nan
     end
     ρc = 1/Vc
     function dp(ρ,T)
-        _,dpdV = p∂p∂V(model,1/ρ,T)
-        return -dpdV*ρ*ρ
+        _,dpdV = p∂p∂V(model,1/ρ,T,z)
+        return -sum(z)*dpdV*ρ*ρ
     end
     #Solvers.derivative(dρ -> pressure(model, 1/dρ, T), ρ)
     _,d2p,d3p = Solvers.∂J2(dp,ρc,Tc)
@@ -1038,8 +1038,8 @@ Given critical information and a pressure, extrapolate the saturation temperatur
     This function will not check if the input pressure is over the critical point.
 
 """
-function critical_tsat_extrapolation(model,p,Tc,Pc,Vc)
-    _p(_T) = pressure(model,Vc,_T)
+function critical_tsat_extrapolation(model,p,Tc,Pc,Vc,z = SA[1.0])
+    _p(_T) = pressure(model,Vc,_T,z)
     dpdT = Solvers.derivative(_p,Tc)
     dTinvdlnp = -Pc/(dpdT*Tc*Tc)
     Δlnp = log(p/Pc)

--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -900,16 +900,17 @@ function x0_saturation_temperature_refine(model,p,T0::XX = 0.9*T_scale(model)*on
 end
 
 """
-    x0_crit_pure(model::EoSModel)
+    x0_crit_pure(model::EoSModel,z)
 Returns a 2-tuple corresponding to
     `(k,log10(Vc0))`, where `k` is `Tc0/T_scale(model,z)`
 """
 function x0_crit_pure end
 
-function x0_crit_pure(model::EoSModel)
-    z = SA[1.0]
+x0_crit_pure(model) = x0_crit_pure(model,SA[1.0])
+
+function x0_crit_pure(model::EoSModel,z)
     Ts = T_scale(model,z)
-    lb_v = lb_volume(model,Ts,z)
+    lb_v = lb_volume(model,Ts,z)/sum(z)
     (1.5, log10(lb_v/0.3))
 end
 

--- a/src/methods/property_solvers/Pproperty.jl
+++ b/src/methods/property_solvers/Pproperty.jl
@@ -1,13 +1,38 @@
-function x0_Pproperty(model::EoSModel,T,z::AbstractVector,verbose = false)
-  bubble = Clapeyron.bubble_pressure(model,T,z)
-  dew = Clapeyron.dew_pressure(model,T,z)
-  if isnan(bubble[1])
-    verbose && @error "bubble_pressure calculation failed."
+function x0_edge_pressure(model,T,z,pure = split_pure_model(model))
+  sat = extended_saturation_pressure.(pure,T)
+  n = sum(z)
+  p_bubble = sum(z[i]*first(sat[i]) for i in 1:length(model))/n
+  p_dew = n/sum(z[i]/first(sat[i]) for i in 1:length(model))
+  return (p_bubble,p_dew),(pure,sat)
+end
+
+function edge_pressure(model,T,z,v0 = nothing)
+  if v0 == nothing
+    vv0,_ = x0_edge_pressure(model,T,z)
+  else
+    vv0 = (v0[1],v0[2])
   end
-  if isnan(dew[1])
-    verbose && @error "dew_pressure calculation failed."
+  p1 = vv0[1]
+  p2 = vv0[2]
+  pmin,pmax = minmax(p1,p2)
+  v_pmin = volume(model,pmin,T,z,phase = :v)
+  v_pmax = volume(model,pmax,T,z,phase = :l)
+  f(x) = μp_equality1_p(model,exp(x[1]),exp(x[2]),T,z)
+  TT = T*one(Base.promote_eltype(model,v_pmin,v_pmax,T))
+  V0 = svec2(log(v_pmin),log(v_pmax),TT)
+
+  if !_is_positive((v_pmin,v_pmax,T))
+    _0 = zero(V0[1])
+    nan = _0/_0
+    fail = (nan,nan,nan)
+    return fail
   end
-  return bubble,dew
+
+  sol = Solvers.nlsolve2(f,V0,Solvers.Newton2Var())
+  v1 = exp(sol[1])
+  v2 = exp(sol[2])
+  p_eq = pressure(model,v2,T,z)
+  return p_eq,v1,v2
 end
 
 
@@ -77,164 +102,47 @@ function _Pproperty(model::EoSModel,T,prop,z = SA[1.0],
     return __Pproperty_check(res,verbose)
   end
 
-  bubble,dew = x0_Pproperty(model,T,z,verbose)
-  bubble_p,bubble_vl,bubble_vv,w_bubble = bubble
-  dew_p,dew_vl,dew_vv,w_dew = dew
+  P_edge,v_l,v_v = edge_pressure(model,T,z)
 
-  #trivial
-  if property === pressure
-    p = prop*one(bubble_p)
-    β = (p - bubble_p)/(dew_p - bubble_p)
-    if 0 <= β <= 1
-      verbose && @warn "In the phase change region"
-      _new_phase = :eq
-    elseif β > 1
-      _new_phase = :vapour
-    elseif β < 0
-      _new_phase = :liquid
-    else
-      _new_phase = :failure
-    end
-    return p,_new_phase
-  end
-
-  #if any bubble/dew pressure is NaN, try solving for the non-NaN value
-  #if both values are NaN, try solving using p_scale(model,z)
-  if isnan(bubble_p) && !isnan(dew_p)
-
-    #=
-    this happens when there is a mixture with non-condensables (water + hydrogen)
-    we suppose:
-    - the properties of the liquid phase are not affected by changes in pressure (we solve for the gas phase)
-    - the composition of the liquid is approximately equal to the composition of the liquid at the dew point.
-    =#
-  
-    verbose && @warn "non-finite bubble point, trying to solve using the dew point"
-    if property == volume
-      prop_bubble = dew_vl
-      prop_dew = dew_vv
-    else
-      prop_bubble = spec_to_vt(model,dew_vl,T,w_dew,property)
-      prop_dew = spec_to_vt(model,dew_vv,T,z,property)/sum(z)
-    end
-    β = (prop/sum(z) - prop_bubble)/(prop_dew - prop_bubble)
-    if 0 <= β <= 1
-      #strategy: substract the liquid part, and solve for the gas fraction
-      damp = Solvers.positive_linesearch(z/sum(z),w_dew,decay = 0.95) #make sure that the gas fraction is positive
-      βx = damp*(1 - β)*sum(z)
-      new_prop = prop - βx*prop_bubble
-      new_z = z - w_dew * βx
-      px,stx = __Pproperty(model,T,new_prop,new_z,property,rootsolver,:gas,abstol,reltol,threaded,dew_p)
-      stx == :failure && (return dew_p,:eq)
-      return px,:eq
-    end
-    verbose && @info "pressure($property) < pressure(dew point)"
-    return __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,dew_p)
-  elseif !isnan(bubble_p) && isnan(dew_p)
-
-    #=
-    this happens when there is a mixture with non-volatiles (water + dodecatriene)
-    we suppose:
-    - the properties of the liquid phase are not affected by changes in pressure (we solve for the gas phase)
-    - the composition of the liquid is approximately equal to the composition of the liquid at the bubble point.
-    =#
-
-    verbose && @warn "non-finite dew point, trying to solve using the bubble point"
-    if property == volume
-      prop_bubble = bubble_vl
-      prop_dew = bubble_vv
-    else
-      prop_bubble = spec_to_vt(model,bubble_vl,T,z,spec)/sum(z)
-      prop_dew = spec_to_vt(model,bubble_vv,T,w_bubble,spec)
-    end
-    β = (prop/sum(z) - prop_dew)/(prop_bubble - prop_dew)
-    if 0 <= β <= 1
-      damp = Solvers.positive_linesearch(z/sum(z),w_bubble,decay = 0.95) #make sure that the gas fraction is positive
-      βx = damp*(1 - β)*sum(z)
-      new_prop = βx*prop_bubble
-      new_z = w_bubble * βx
-      px,stx = __Pproperty(model,T,new_prop,new_z,property,rootsolver,:gas,abstol,reltol,threaded,bubble_p)
-      stx == :failure && (return bubble_p,:eq)
-      return px,:eq
-    end
-    verbose && @info "pressure($property) > pressure(bubble point)"
-    return __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,bubble_p)
-  elseif isnan(bubble_p) && isnan(dew_p)
-    verbose && @warn "non-finite dew and bubble points, trying to solve using Clapeyron.p_scale(model,z)"
+  if !isfinite(P_edge)
+    verbose && @warn "failure to calculate edge point, trying to solve using Clapeyron.p_scale(model,z)"
     return __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,p_scale(model,z))
   end
+  
+  prop_l = spec_to_vt(model,v_l,T,z,property)
+  prop_v = spec_to_vt(model,v_v,T,z,property)
 
-  if property == volume
-    prop_bubble = bubble_vl*sum(z)
-    prop_dew = dew_vv*sum(z)
-  else
-    prop_bubble = property(model,bubble_p,T,z,phase=phase)
-    prop_dew = property(model,dew_p,T,z,phase=phase)
+  verbose && @info "property at liquid edge:     $prop_l"
+  verbose && @info "property at vapour edge:     $prop_v"
+  verbose && @info "pressure at edge point:      $P_edge"
+
+  β = (prop - prop_l)/(prop_v - prop_l)
+  @show 
+  #we are inside equilibria.
+  if 0 <= β <= 1
+    verbose && @info "property between the liquid and vapour edges, in the phase change region"
+    return P_edge,:eq
   end
 
-  F(P) = property(model,P,T,z)
-
-  if verbose
-    @info "input property:              $prop"
-    @info "property at dew point:       $prop_dew"
-    @info "property at bubble point:    $prop_bubble"
-    @info "pressure at dew point:       $dew_p"
-    @info "pressure at bubble point:    $bubble_p"
-  end
-
-  β = (prop - prop_dew)/(prop_bubble - prop_dew)
-
+  #gas side, maybe eq, maybe not
   if β > 1
-    verbose && @info "pressure($property) > pressure(bubble point)"
-    res = __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,bubble_p)
+    res = __Pproperty(model,T,prop,z,property,rootsolver,:vapour,abstol,reltol,threaded,P_edge)
+    ψ_stable = diffusive_stability(model,res[1],T,z,phase = :vapour)
+    !ψ_stable && verbose && @info "pseudo-vapour pressure($property) in phase change region (diffusively unstable)"
+    !ψ_stable && return __Pproperty_check((res[1],:eq),verbose,P_edge)
+    #TODO: hook dew pressure here
     return __Pproperty_check(res,verbose)
-  elseif β < 0
-    verbose && @info "pressure($property) < pressure(dew point)"
-    res = __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,dew_p)
-    return __Pproperty_check(res,verbose)
-  elseif 0 <= β <= 1
-
-    P_edge,prop_edge_dew,prop_edge_bubble = FindEdge(F,dew_p,bubble_p) # dew_p < bubble_p --> condition for FindEdge
-    px0 = exp(β*log(bubble_p) + (1 - β)*log(dew_p))
-
-    if !isfinite(P_edge)
-      verbose && @warn "failure to calculate edge point"
-      verbose && @warn "$property in the phase change region, returning a linear interpolation of the bubble and dew pressures"
-      return px0,:eq
-    end
-
-    verbose && @info "property at dew edge:        $prop_edge_dew"
-    verbose && @info "property at bubble edge:     $prop_edge_bubble"
-    verbose && @info "pressure at edge point:      $P_edge"
-
-    #=
-    the order is the following:
-    bubble -> edge_bubble -> edge_dew -> dew
-    or:
-    dew -> edge_dew -> edge_bubble -> bubble
-    =#
-
-    βedge = (prop - prop_edge_bubble)/(prop_edge_dew - prop_edge_bubble)
-    βedge_bubble = (prop - prop_edge_bubble)/(prop_bubble - prop_edge_bubble)
-    βedge_dew = (prop - prop_edge_dew)/(prop_dew - prop_edge_dew)
-
-    if 0 <= βedge <= 1
-      verbose && @warn "In the phase change region"
-      return P_edge,:eq
-    elseif βedge < 0 #prop <= prop_edge2
-      verbose && @info "pressure($property) ∈ (pressure(bubble point),pressure(edge point))"
-      P_edge_bubble = exp(βedge_bubble*log(bubble_p) + (1 - βedge_bubble)*log(P_edge))
-      property == volume && return P_edge_bubble,:eq
-      px,_ = __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,P_edge_bubble)
-      return __Pproperty_check((px,:eq),verbose,P_edge_bubble)
-    elseif βedge > 1
-      verbose && @info "pressure($property) ∈ (pressure(edge point),pressure(dew point))"
-      P_edge_dew = exp(βedge_dew*log(dew_p) + (1 - βedge_dew)*log(P_edge))
-      property == volume && return P_edge_bubble,:eq
-      px,_ = __Pproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,P_edge_dew)
-      return __Pproperty_check((px,:eq),verbose,P_edge_dew)
-    end
   end
+
+  if β < 0
+    res = __Pproperty(model,T,prop,z,property,rootsolver,:liquid,abstol,reltol,threaded,P_edge)
+    ψ_stable = diffusive_stability(model,res[1],T,z,phase = :liquid)
+    !ψ_stable && verbose && @info "pseudo-liquid pressure($property) in phase change region (diffusively unstable)."
+    !ψ_stable && return __Pproperty_check((res[1],:eq),verbose,P_edge)
+    #TODO: hook bubble pressure here
+    return __Pproperty_check(res,verbose)
+  end
+
   _0 = zero(Base.promote_eltype(model,T,prop,z))
   return __Pproperty_check((_0/_0,:failure),verbose)
 end

--- a/src/methods/property_solvers/Pproperty.jl
+++ b/src/methods/property_solvers/Pproperty.jl
@@ -6,6 +6,16 @@ function x0_edge_pressure(model,T,z,pure = split_pure_model(model))
   return (p_bubble,p_dew),sat
 end
 
+"""
+    edge_pressure(model,p,z,v0 = nothing)
+
+Calculates the pressure at which two fluid phases have the same gibbs and pressure at the specified temperature.
+
+Returns a tuple, containing:
+- Edge Pressure `[Pa]`
+- Liquid volume of edge Point `[m³]`
+- Vapour volume at edge Point `[m³]`
+"""
 function edge_pressure(model,T,z,v0 = nothing)
   edge,crit,status = _edge_pressure(model,T,z,v0)
   return edge
@@ -365,4 +375,4 @@ sol1 = Pproperty(model,T,h_,z,enthalpy)
 sol2 = Pproperty(model,T,s_,z,entropy)
 sol3 = Pproperty(model,T,ρ_,z,mass_density) =#
 
-export Pproperty
+export Pproperty, edge_pressure

--- a/src/methods/property_solvers/Pproperty.jl
+++ b/src/methods/property_solvers/Pproperty.jl
@@ -127,15 +127,19 @@ function _Pproperty(model::EoSModel,T,prop,z = SA[1.0],
     return __Pproperty_check(res,verbose)
   end
 
-  edge,crit,status = _edge_pressure(model,T,z)
+  v0_edge,v0_bubbledew = x0_edge_pressure(model,T,z)
+  edge,crit,status = _edge_pressure(model,T,z,v0_edge)
   P_edge,v_l,v_v = edge
 
   if status == :supercritical
+    #=
+    TODO: what to do in this zone? 
+    we are smooth in the p-v curves, 
+    but there are still phase separation up until the mixture critical point. =#
     Tc,Pc,Vc = crit
     verbose && @info "mechanical critical pressure:        $Pc"
     verbose && @info "mechanical critical temperature:     $Tc"
-    verbose && @info "pressure($property) over mechanical critical point"
-    res = __Pproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,Pc)
+    res = __Pproperty(model,T,prop,z,property,rootsolver,:vapour,abstol,reltol,threaded,Pc)
     res[2] == :failure && return __Pproperty_check(res,verbose)
     ψ_stable = diffusive_stability(model,res[1],T,z,phase = :vapour)
     !ψ_stable && verbose && @info "pseudo-critical pressure($property) in phase change region (diffusively unstable)"

--- a/src/methods/property_solvers/Pproperty.jl
+++ b/src/methods/property_solvers/Pproperty.jl
@@ -117,7 +117,6 @@ function _Pproperty(model::EoSModel,T,prop,z = SA[1.0],
   verbose && @info "pressure at edge point:      $P_edge"
 
   β = (prop - prop_l)/(prop_v - prop_l)
-  @show 
   #we are inside equilibria.
   if 0 <= β <= 1
     verbose && @info "property between the liquid and vapour edges, in the phase change region"

--- a/src/methods/property_solvers/Pproperty.jl
+++ b/src/methods/property_solvers/Pproperty.jl
@@ -178,12 +178,12 @@ function _Pproperty(model::EoSModel,T,prop,z = SA[1.0],
     Vx = volume(model,px,T,z,vol0 = Vc*n)/n
 
     if Vx <= Vc
-      bubble_method_crit = bubble_pressure_pproperty_method(model,1.01Pc,Tc,z,pure_sats)
+      bubble_method_crit = bubble_pressure_pproperty_method(model,Pc,Tc,z,pure_sats)
       Psat,Vsat,_,_ = bubble_pressure(model,Tc,z,bubble_method_crit)
       satpoint = "bubble"
       verbose && @info "molar volume at bubble point:        $Vsat"
     else
-      dew_method_crit = dew_pressure_pproperty_method(model, 0.99Pc,Tc,z,pure_sats)
+      dew_method_crit = dew_pressure_pproperty_method(model,Pc,Tc,z,pure_sats)
       Psat,_,Vsat,_ = dew_pressure(model,Tc,z,dew_method_crit)
       satpoint = "dew"
       verbose && @info "molar volume at dew point:           $Vsat"

--- a/src/methods/property_solvers/Tproperty.jl
+++ b/src/methods/property_solvers/Tproperty.jl
@@ -1,17 +1,60 @@
-"""
-    `x0_Tproperty(model::EoSModel,p,z::AbstractVector)`
-Peforms some initial checks to see if a possible solution exists in `Clapeyron.jl`.
-"""
-function x0_Tproperty(model::EoSModel,p,z::AbstractVector,verbose = false)
-    bubble = Clapeyron.bubble_temperature(model,p,z)
-    dew = Clapeyron.dew_temperature(model,p,z)
-    if isnan(bubble[1])
-      verbose && @error "bubble_temperature calculation failed."
-    end
-    if isnan(dew[1])
-      verbose && @error "dew_temperature calculation failed."
-    end
-    return bubble,dew
+normalize_property(model,prop,z,property::F) where F = prop,property
+normalize_property(model,prop,z,property::typeof(molar_density)) = sum(z)/prop,volume
+normalize_property(model,prop,z,property::typeof(mass_density)) = molecular_weight(model,z)/prop,volume
+
+function x0_edge_temperature(model,p,z,pure = split_pure_model(model))
+  dPdTsat = extended_dpdT_temperature.(pure,p)
+  T_bubble = antoine_bubble_solve(dPdTsat,p,z)
+  T_dew = antoine_dew_solve(dPdTsat,p,z)
+  return (T_bubble,T_dew),(pure,dPdTsat)
+end
+
+function μp_equality1_T2(model,p,z,x,Ts)
+    lnv1,lnv2,T1,T2 = x
+    n = sum(z)
+    v1,v2 = exp(lnv1),exp(lnv2)
+    RT1,RT2 = n*Rgas(model)*T1,n*Rgas(model)*T2
+    f1(V) = a_res(model,V,T1,z)
+    f2(V) = a_res(model,V,T2,z)
+    A1,Av1 = Solvers.f∂f(f1,v1)
+    A2,Av2 =Solvers.f∂f(f2,v2)
+    p1,p2 = RT1*(-Av1 + 1/v1),RT2*(-Av2 + 1/v2)
+    Δμᵣ = A1 - v1*Av1 - A2 + v2*Av2 + log(v2/v1)
+    Fμ = Δμᵣ
+    Fp1 = (p1 - p)/p
+    Fp2 = (p2 - p)/p
+    FT = (T1 - T2)/Ts
+    return SVector(Fμ,Fp1,Fp2,FT)
+end
+
+function edge_temperature(model,p,z,v0 = nothing)
+  if v0 == nothing
+    vv0,_ = x0_edge_temperature(model,p,z)
+  else
+    vv0 = (v0[1],v0[2])
+  end
+  T1 = vv0[1]
+  T2 = vv0[2]
+  Tmin,Tmax = minmax(T1,T2)
+  n = sum(z)
+  v_Tmin = volume(model,p,Tmin,z,phase = :l)
+  v_Tmax = volume(model,p,Tmax,z,phase = :v)
+  Ts = 0.5*(T1 + T2)
+  f(x) = μp_equality1_T2(model,p,z,x,Ts)
+  V0 = SVector(promote(log(v_Tmin),log(v_Tmax),Tmin,Tmax))
+
+  if !_is_positive((v_Tmin,v_Tmax,Tmin,Tmax))
+    _0 = zero(V0[1])
+    nan = _0/_0
+    fail = (nan,nan,nan)
+    return fail
+  end
+
+  sol = Solvers.nlsolve2(f,V0,Solvers.Newton2Var())
+  v1 = exp(sol[1])
+  v2 = exp(sol[2])
+  T_eq = 0.5*(sol[3] + sol[4])
+  return T_eq,v1,v2
 end
 
 """
@@ -24,26 +67,26 @@ function FindEdge(f::T,a,b) where T
   return FindEdge(f,a,b,fa,fb)
 end
 
-function FindEdge(f::T,a,b,fa,fb) where T
-  @assert a <= b
-  if isapprox(a,b,atol=1e-10)
-    return a,fa,fb
-  end
-    c = (a+b)/2
+function FindEdge(f::T,_a,_b,_fa,_fb) where T
+  @assert _a <= _b
+
+  a,b,fa,fb = promote(_a,_b,_fa,_fb)
+  for i in 1:40
+    isapprox(a,b,rtol=1e-10,atol = 1e-10) && return a,fa,fb
+    c = 0.5*(a+b)
     fc = f(c)
     ∇fa,∇fc = (fc - fa)/(c - a),(fb - fc)/(b - a)
     if abs(∇fc) > abs(∇fa)
-      FindEdge(f,c,b,fc,fb)
+      a = c
+      fa = fc
     else
-      FindEdge(f,a,c,fa,fc)
+      b = c
+      fb = fc
     end
+  end
+  nan = zero(a)/zero(a)
+  return nan,nan,nan
 end
-
-
-normalize_property(model,prop,z,property::F) where F = prop,property
-normalize_property(model,prop,z,property::typeof(molar_density)) = sum(z)/prop,volume
-normalize_property(model,prop,z,property::typeof(mass_density)) = molecular_weight(model,z)/prop,volume
-
 
 """
     Tproperty(model::EoSModel,p,prop,z::AbstractVector,property = enthalpy;rootsolver = Roots.Order0(),phase =:unknown,abstol = 1e-15,reltol = 1e-15, verbose = false)
@@ -115,143 +158,46 @@ function _Tproperty(model::EoSModel,p,prop,z = SA[1.0],
     return __Tproperty_check(res,verbose)
   end
 
-  bubble,dew = x0_Tproperty(model,p,z,verbose)
-  bubble_T,bubble_vl,bubble_vv,w_bubble = bubble
-  dew_T,dew_vl,dew_vv,w_dew = dew
+  T_edge,v_l,v_v = edge_temperature(model,p,z)
 
-  #trivial
-  if property === temperature
-    T = prop*one(bubble_T)
-    β = (T - dew_T)/(bubble_T - dew_T)
-    if 0 <= β <= 1
-      verbose && @warn "In the phase change region"
-      _new_phase = :eq
-    elseif β > 1
-      _new_phase = :vapour
-    elseif β < 0
-      _new_phase = :liquid
-    else
-      _new_phase = :failure
-    end
-    return T,_new_phase
+  if !isfinite(T_edge)
+    verbose && @warn "failure to calculate edge point, trying to solve using Clapeyron.T_scale(model,z)"
+    res = __Tproperty(model,T,prop,z,property,rootsolver,phase,abstol,reltol,threaded,T_scale(model,z))
+    return __Tproperty_check(res,verbose)
+  end
+  
+  prop_l = spec_to_vt(model,v_l,T_edge,z,property)
+  prop_v = spec_to_vt(model,v_v,T_edge,z,property)
+
+  verbose && @info "property at liquid edge:     $prop_l"
+  verbose && @info "property at vapour edge:     $prop_v"
+  verbose && @info "temperature at edge point:   $P_edge"
+
+  β = (prop - prop_l)/(prop_v - prop_l)
+
+  #we are inside equilibria.
+  if 0 <= β <= 1
+    verbose && @info "property between the liquid and vapour edges, in the phase change region"
+    return P_edge,:eq
   end
 
-  #if any bubble/dew temp is NaN, try solving for the non-NaN value
-  #if both values are NaN, try solving using T_scale(model,z)
-  if isnan(bubble_T) && !isnan(dew_T)
-    verbose && @warn "non-finite bubble point, trying to solve using the dew point"
-    if property == volume
-      prop_bubble = dew_vl
-      prop_dew = dew_vv
-    else
-      prop_bubble = spec_to_vt(model,dew_vl,dew_T,w_dew,property)
-      prop_dew = spec_to_vt(model,dew_vv,dew_T,z,property)/sum(z)
-    end
-    β = (prop/sum(z) - prop_bubble)/(prop_dew - prop_bubble)
-    if 0 <= β <= 1
-      #strategy: substract the liquid part, and solve for the gas fraction
-      #damp = Solvers.positive_linesearch(z/sum(z),w_dew,decay = 0.95) #make sure that the gas fraction is positive
-      #βx = damp*(1 - β)*sum(z)
-      #new_prop = prop - βx*prop_bubble
-      #new_z = z - w_dew * βx
-      #Tx,stx = __Tproperty(model,p,new_prop,new_z,property,rootsolver,:gas,abstol,reltol,threaded,dew_T)
-      #stx == :failure && (return dew_T,:eq)
-      return dew_T,:eq
-    end
-    verbose && @info "pressure($property) < pressure(dew point)"
-    return __Pproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,dew_T)
-  elseif !isnan(bubble_T) && isnan(dew_T)
-    verbose && @warn "non-finite dew point, trying to solve using the bubble point"
-    if property == volume
-      prop_bubble = bubble_vl
-      prop_dew = bubble_vv
-    else
-      prop_bubble = spec_to_vt(model,bubble_vl,bubble_T,z,property)/sum(z)
-      prop_dew = spec_to_vt(model,bubble_vv,bubble_T,w_bubble,property)
-    end
-
-    β = (prop/sum(z) - prop_dew)/(prop_bubble - prop_dew)
-    0 <= β <= 1 && (return bubble_T,:eq)
-    verbose && @info "pressure($property) > pressure(bubble point)"
-    return __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,bubble_T)
-  elseif isnan(bubble_T) && isnan(dew_T)
-    verbose && @warn "non-finite dew and bubble points, trying to solve using Clapeyron.T_scale(model,z)"
-    return __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,T_scale(model,z))
-  end
-
-  if property == volume
-    prop_bubble = bubble_vl*sum(z)
-    prop_dew = dew_vv*sum(z)
-  else
-    prop_bubble = property(model,p,bubble_T,z,phase=phase)
-    prop_dew = property(model,p,dew_T,z,phase=phase)
-  end
-
-  F(T) = property(model,p,T,z)
-
-  if verbose
-    @info "input property:              $prop"
-    @info "property at dew point:       $prop_dew"
-    @info "property at bubble point:    $prop_bubble"
-    @info "temperature at dew point:    $dew_T"
-    @info "temperature at bubble point: $bubble_T"
-  end
-
-  β = (prop - prop_dew)/(prop_bubble - prop_dew)
-
+  #gas side, maybe eq, maybe not
   if β > 1
-    verbose && @info "temperature($property) < temperature(bubble point)"
-    res = __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,bubble_T)
+    res = __Tproperty(model,T,prop,z,property,rootsolver,:vapour,abstol,reltol,threaded,T_edge)
+    ψ_stable = diffusive_stability(model,p,res[1],z,phase = :vapour)
+    !ψ_stable && verbose && @info "pseudo-vapour temperature($property) in phase change region (diffusively unstable)"
+    !ψ_stable && return __Tproperty_check((res[1],:eq),verbose,T_edge)
+    #TODO: hook dew temperature here
     return __Tproperty_check(res,verbose)
-  elseif β < 0
-    verbose && @info "temperature($property) > temperature(dew point)"
-    res = __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,dew_T)
+  end
+
+  if β < 0
+    res = __Tproperty(model,T,prop,z,property,rootsolver,:liquid,abstol,reltol,threaded,P_edge)
+    ψ_stable = diffusive_stability(model,p,res[1],z,phase = :liquid)
+    !ψ_stable && verbose && @info "pseudo-liquid temperature($property) in phase change region (diffusively unstable)."
+    !ψ_stable && return __Tproperty_check((res[1],:eq),verbose,T_edge)
+    #TODO: hook bubble temperature here
     return __Tproperty_check(res,verbose)
-  elseif 0 <= β <= 1
-
-    if property == volume
-      verbose && @info "$property in the phase change region, returning a linear interpolation of the bubble and dew temperatures"
-      return β*bubble_T + (1 - β)*dew_T,:eq
-    end
-
-    T_edge,prop_edge_bubble,prop_edge_dew = FindEdge(F,bubble_T,dew_T)
-
-    if !isfinite(T_edge)
-      verbose && @error "failure to calculate edge point"
-      verbose && @warn "$property in the phase change region, returning a linear interpolation of the bubble and dew temperatures"
-      return β*bubble_T + (1 - β)*dew_T,:eq
-    end
-    verbose && @info "property at dew edge:        $prop_edge_dew"
-    verbose && @info "property at bubble edge:     $prop_edge_bubble"
-    verbose && @info "temperature at edge point:   $T_edge"
-
-    #=
-    the order is the following:
-    bubble -> edge_bubble -> edge_dew -> dew
-    or:
-    dew -> edge_dew -> edge_bubble -> bubble
-    =#
-
-    βedge = (prop - prop_edge_bubble)/(prop_edge_dew - prop_edge_bubble)
-    βedge_bubble = (prop - prop_edge_bubble)/(prop_bubble - prop_edge_bubble)
-    βedge_dew = (prop - prop_edge_dew)/(prop_dew - prop_edge_dew)
-
-    if 0 <= βedge <= 1
-      verbose && @warn "In the phase change region"
-      return T_edge,:eq
-    elseif βedge > 1
-      verbose && @info "temperature($property) ∈ (temperature(dew point),temperature(edge point))"
-      T_edge_dew = βedge_dew*dew_T + (1 - βedge_dew)*T_edge
-      #TODO: we could skip this calculation when Tproperty is used as initial point.
-      Tx,_ = __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,T_edge_dew)
-      return __Tproperty_check((Tx,:eq),verbose,T_edge)
-    elseif βedge < 0
-      verbose && @info "temperature($property) ∈ (temperature(edge point),temperature(bubble point))"
-      T_edge_bubble = βedge_bubble*bubble_T + (1 - βedge_bubble)*T_edge
-      #TODO: we could skip this calculation when Tproperty is used as initial point.
-      Tx,_ = __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,T_edge_bubble)
-      return __Tproperty_check((Tx,:eq),verbose,T_edge)
-    end
   end
 
   _0 = zero(Base.promote_eltype(model,p,prop,z))

--- a/src/methods/property_solvers/Tproperty.jl
+++ b/src/methods/property_solvers/Tproperty.jl
@@ -237,12 +237,12 @@ function _Tproperty(model::EoSModel,p,prop,z = SA[1.0],
     Vx = volume(model,p,Tx,z,vol0 = Vc*n)/n
 
     if Vx <= Vc
-      bubble_method_crit = bubble_temperature_tproperty_method(model,p,0.99Tc,z,dpdT)
+      bubble_method_crit = bubble_temperature_tproperty_method(model,Pc,Tc,z,dpdT)
       Tsat,Vsat,_,_ = bubble_temperature(model,Pc,z,bubble_method_crit)
       satpoint = "bubble"
       verbose && @info "molar volume at bubble point:           $Vsat"
     else
-      dew_method_crit = dew_temperature_tproperty_method(model,p,1.001Tc,z,dpdT)
+      dew_method_crit = dew_temperature_tproperty_method(model,Pc,Tc,z,dpdT)
       Tsat,_,Vsat,_ = dew_temperature(model,Pc,z,dew_method_crit)
       satpoint = "dew"
       verbose && @info "molar volume at dew point:              $Vsat"

--- a/src/methods/property_solvers/Tproperty.jl
+++ b/src/methods/property_solvers/Tproperty.jl
@@ -186,15 +186,19 @@ function _Tproperty(model::EoSModel,p,prop,z = SA[1.0],
     return __Tproperty_check(res,verbose)
   end
 
-  edge,crit,status = _edge_temperature(model,p,z)
+  v0_edge,v0_bubbledew = x0_edge_temperature(model,p,z)
+  edge,crit,status = _edge_temperature(model,p,z,v0_edge)
   T_edge,v_l,v_v = edge
 
   if status == :supercritical
+    #=
+    TODO: what to do in this zone? 
+    we are smooth in the p-v curves, 
+    but there are still phase separation up until the mixture critical point. =#
     Tc,Pc,Vc = crit
     verbose && @info "mechanical critical pressure:        $Pc"
     verbose && @info "mechanical critical temperature:     $Tc"
-    verbose && @info "temperature($property) over mechanical critical point"
-    res = __Tproperty(model,p,prop,z,property,rootsolver,phase,abstol,reltol,threaded,Tc)
+    res = __Tproperty(model,p,prop,z,property,rootsolver,:vapour,abstol,reltol,threaded,Tc)
     res[2] == :failure && return __Tproperty_check(res,verbose)
     ψ_stable = diffusive_stability(model,p,res[1],z,phase = :vapour)
     !ψ_stable && verbose && @info "pseudo-critical temperature($property) in phase change region (diffusively unstable)"

--- a/src/methods/property_solvers/Tproperty.jl
+++ b/src/methods/property_solvers/Tproperty.jl
@@ -27,12 +27,23 @@ function μp_equality1_T2(model,p,z,x,Ts)
     return SVector(Fμ,Fp1,Fp2,FT)
 end
 
-mechanical_critical_point(model,z,x0) = crit_pure(model,x0,z)
 
+"""
+    edge_temperature(model,p,z,v0 = nothing)
+
+Calculates the temperature at which two fluid phases have the same gibbs and temperature at the specified pressure.
+
+Returns a tuple, containing:
+- Edge Temperature `[K]`
+- Liquid volume of edge Point `[m³]`
+- Vapour volume at edge Point `[m³]`
+"""
 function edge_temperature(model,p,z,v0 = nothing)
   edge,crit,status = _edge_temperature(model,p,z,v0)
   return edge
 end
+
+edge_temperature(model,p) = saturation_temperature(model,p)
 
 function _edge_temperature(model,p,z,v0 = nothing)
   if v0 == nothing
@@ -492,4 +503,4 @@ end
 # sol3 = Tproperty(model,p,ρ_,z,mass_density)
 # sol4 = Tproperty(model,p,ic_,z,isentropic_compressibility)
 
-export Tproperty
+export Tproperty, edge_temperature

--- a/src/methods/property_solvers/multicomponent/LLE_point.jl
+++ b/src/methods/property_solvers/multicomponent/LLE_point.jl
@@ -50,8 +50,8 @@ Calculates the Liquid-Liquid equilibrium pressure and properties at a given temp
 
 Returns a tuple, containing:
 - LLE Pressure `[Pa]`
-- Liquid volume of composition `x₁ = x` at LLE Point `[m³]`
-- Liquid volume of composition `x₂` at LLE Point  `[m³]`
+- Liquid molar volume of composition `x₁ = x` at LLE Point `[m³·mol⁻¹]`
+- Liquid molar volume of composition `x₂` at LLE Point  `[m³·mol⁻¹]`
 - Liquid composition `x₂`
 """
 function LLE_pressure(model::EoSModel, T, x; v0 =nothing)
@@ -91,8 +91,8 @@ Calculates the Liquid-Liquid equilibrium temperature and properties at a given p
 
 Returns a tuple, containing:
 - LLE Pressure `[Pa]`
-- Liquid volume of composition `x₁ = x` at LLE Point `[m³]`
-- Liquid volume of composition `x₂` at LLE Point  `[m³]`
+- Liquid molar volume of composition `x₁ = x` at LLE Point `[m³·mol⁻¹]`
+- Liquid molar volume of composition `x₂` at LLE Point  `[m³·mol⁻¹]`
 - Liquid composition `x₂`
 """
 function LLE_temperature(model::EoSModel,p,x;v0=nothing)

--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -271,7 +271,7 @@ function improve_bubbledew_suggestion(model,p0,T0,x,y,method,in_media,high_condi
         y_r = rr_flash_vapor(K_r,x_r,zero(eltype(K)))
         yy = index_expansion(y_r,in_media)
         yy ./= sum(yy)
-        vv = volume(model,p,T,y,phase = :v)
+        vv = volume(model,p,T,yy,phase = :v)
         return p,T,x,yy,vlx/sum(x),vv
     else
         y_r = @view y[in_media]

--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -356,8 +356,8 @@ end
 Calculates the bubble pressure and properties at a given temperature `T`.
 Returns a tuple, containing:
 - Bubble Pressure `[Pa]`
-- Liquid volume at Bubble Point `[m³]`
-- Vapour volume at Bubble Point `[m³]`
+- Liquid molar volume at Bubble Point `[m³·mol⁻¹]`
+- Vapour molar volume at Bubble Point `[m³·mol⁻¹]`
 - Vapour composition at Bubble Point
 
 By default, uses equality of chemical potentials, via [`ChemPotBubblePressure`](@ref)

--- a/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
@@ -133,7 +133,7 @@ Function to compute [`bubble_temperature`](@ref) via chemical potentials.
 It directly solves the equality of chemical potentials system of equations.
 
 Inputs:
-- `y = nothing`: optional, initial guess for the vapor phase composition.
+- `y0 = nothing`: optional, initial guess for the vapor phase composition.
 - `T0 = nothing`: optional, initial guess for the bubble temperature `[K]`.
 - `vol0 = nothing`: optional, initial guesses for the liquid and vapor phase volumes `[m³]`
 - `atol = 1e-8`: optional, absolute tolerance of the non linear system of equations

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -205,7 +205,7 @@ function dew_temperature_init(model,p,y,vol0,T0,x0,condensables)
                 vl,vv = vol0
             else
                 vl = volume(model,p,T0,x0,phase = :l)
-                vv = volume(model,p,T0,y,phase =:v)
+                vv = volume(model,p,T0,y,phase = :v)
             end
         else
             T0,vl0,vv0,_ = __x0_dew_temperature(model,p,y,T0,condensables)

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -85,8 +85,8 @@ end
 Calculates the dew pressure and properties at a given temperature `T`.
 Returns a tuple, containing:
 - Dew Pressure `[Pa]`
-- Liquid volume at Dew Point `[m³]`
-- Vapour volume at Dew Point `[m³]`
+- Liquid molar volume at Dew Point `[m³·mol⁻¹]`
+- Vapour molar volume at Dew Point `[m³·mol⁻¹]`
 - Liquid composition at Dew Point
 
 By default, uses equality of chemical potentials, via [`ChemPotDewPressure`](@ref)
@@ -236,8 +236,8 @@ end
 Calculates the dew temperature and properties at a given pressure `p`.
 Returns a tuple, containing:
 - Dew Temperature `[K]`
-- Liquid volume at Dew Point `[m³]`
-- Vapour volume at Dew Point `[m³]`
+- Liquid molar volume at Dew Point `[m³·mol⁻¹]`
+- Vapour molar volume at Dew Point `[m³·mol⁻¹]`
 - Liquid composition at Dew Point
 
 By default, uses equality of chemical potentials, via [`ChemPotDewTemperature`](@ref)

--- a/src/methods/property_solvers/multicomponent/multicomponent.jl
+++ b/src/methods/property_solvers/multicomponent/multicomponent.jl
@@ -206,7 +206,7 @@ function wilson_k_values!(K,model::EoSModel,p,T,crit)
 end
 
 function bubbledew_check(model,p,T,vw,vz,w,z)
-    (isapprox(vw,vz) && isapprox(w,z)) && return false
+    (isapprox(vw,vz) && z_norm(z,w) < 1e-5) && return false
     !all(isfinite,w) && return false
     !isfinite(vw) && return false
     !all(>=(0),w) && return false

--- a/src/methods/property_solvers/multicomponent/multicomponent.jl
+++ b/src/methods/property_solvers/multicomponent/multicomponent.jl
@@ -391,6 +391,6 @@ include("solids/eutectic_point.jl")
 export bubble_pressure_fug, bubble_temperature_fug, dew_temperature_fug, dew_pressure_fug
 export bubble_pressure,    dew_pressure,    LLE_pressure,    azeotrope_pressure, VLLE_pressure
 export bubble_temperature, dew_temperature, LLE_temperature, azeotrope_temperature, VLLE_temperature
-export crit_mix, UCEP_mix, UCST_pressure, UCST_temperature, UCST_mix
+export crit_mix, UCEP_mix, UCST_pressure, UCST_temperature, UCST_mix, mechanical_critical_point
 export krichevskii_parameter
 export sle_solubility, sle_solubility_T, eutectic_point, slle_solubility

--- a/src/methods/property_solvers/singlecomponent/crit_pure.jl
+++ b/src/methods/property_solvers/singlecomponent/crit_pure.jl
@@ -13,14 +13,14 @@ function crit_pure(model::EoSModel)
     end
 end
 
-function crit_pure(model::EoSModel,x0;options = NEqOptions())
-    single_component_check(crit_pure,model)
+function crit_pure(model::EoSModel,x0,z = SA[1.0];options = NEqOptions())
+    check_arraysize(model,z)
     #f! = (F,x) -> obj_crit(model, F, x[1]*T̄, exp10(x[2]))
     if x0 === nothing
         x0 = x0_crit_pure(model)
     end
     x01,x02 = x0
-    T̄  = T_scale(model)*one(x01*one(x02))
+    T̄  = T_scale(model,z)*one(x01*one(x02))
     #if type !== nothing
     #    T̄ = T̄*oneunit(type)
     #end
@@ -28,50 +28,50 @@ function crit_pure(model::EoSModel,x0;options = NEqOptions())
     #x0 = SVector(_1*x01,_1*x02)
     x0 = vec2(primalval(x01),primalval(x02*log(10)),primalval(_1))
     primalmodel = primalval(model)
-    f!(F,x) = ObjCritPure(primalmodel,F,primalval(T̄),x)
+    zz = z/sum(z)
+    f!(F,x) = ObjCritPure(primalmodel,F,primalval(T̄),x,zz)
     solver_res = Solvers.nlsolve(f!, x0, TrustRegion(Newton(), NLSolvers.NWI()), options)
     #display(solver_res)
     r  = Solvers.x_sol(solver_res)
     T_c = r[1]*T̄
     V_c = exp(r[2])
-    p_c = pressure(model, V_c, T_c)
-
+    p_c = pressure(model, V_c, T_c, zz)
     crit = (T_c, p_c, V_c)
-    return crit_pure_ad(model,crit)
+    return crit_pure_ad(model,crit,z)
 end
 
-function crit_pure_ad(model,crit)
+function crit_pure_ad(model,crit,z)
     if has_dual(model)
         T_c_primal, p_c_primal, V_c_primal = crit
         T̄  = T_scale(model)
         x = SVector(T_c_primal/T̄,log(V_c_primal))
-        f(z) = __ObjCritPure(model,T̄,z)
+        f(zz) = __ObjCritPure(model,T̄,z,zz)
         F,J = Solvers.J2(f,x)
         ∂x = J\F
         r = x .- ∂x
         T_c = r[1]*T̄
         V_c = exp(r[2])
-        P_c = pressure(model,V_c,T_c)
+        P_c = pressure(model,V_c,T_c,z)
         return (T_c,P_c,V_c)
     else
         return crit
     end
 end
 
-function ObjCritPure(model::T,F,T̄,x) where T
-    sv = __ObjCritPure(model,T̄,x)
+function ObjCritPure(model::T,F,T̄,x,z) where T
+    sv = __ObjCritPure(model,T̄,x,z)
     F[1] = sv[1]
     F[2] = sv[2]
     return F
 end
 
-function __ObjCritPure(model::T,T̄,x) where T
+function __ObjCritPure(model::T,T̄,x,z) where T
     T_c = x[1]*T̄
     V_c = exp(x[2])
     RT = Rgas(model)*T_c
     ∂²A∂V²_scale = V_c*V_c/RT
     ∂³A∂V³_scale = ∂²A∂V²_scale*V_c
-    ∂²A∂V², ∂³A∂V³ = ∂²³f(model, V_c, T_c, SA[1.0])
+    ∂²A∂V², ∂³A∂V³ = ∂²³f(model, V_c, T_c, z)
     F1 = -∂²A∂V²*∂²A∂V²_scale
     F2 = -∂³A∂V³*∂³A∂V³_scale
     return SVector((F1,F2))

--- a/src/methods/property_solvers/singlecomponent/crit_pure.jl
+++ b/src/methods/property_solvers/singlecomponent/crit_pure.jl
@@ -1,7 +1,12 @@
 """
     crit_pure(model::EoSModel,x0=nothing)
+
 Calculates the critical point of a single component modelled by `model`. 
-Returns `(Tc, pc, Vc)` where `Tc` is the critical temperature (in `[K]`), `pc` is the critical pressure (in `[Pa]`) and `Vc` is the critical volume (in  `[m³]`)
+Returns a tuple, containing:
+
+- Critical temperature `[K]`
+- Critical pressure `[Pa]`
+- Critical molar volume `[m³·mol⁻¹]`
 """
 
 function crit_pure(model::EoSModel)
@@ -17,7 +22,7 @@ function crit_pure(model::EoSModel,x0,z = SA[1.0];options = NEqOptions())
     check_arraysize(model,z)
     #f! = (F,x) -> obj_crit(model, F, x[1]*T̄, exp10(x[2]))
     if x0 === nothing
-        x0 = x0_crit_pure(model)
+        x0 = x0_crit_pure(model,z)
     end
     x01,x02 = x0
     T̄  = T_scale(model,z)*one(x01*one(x02))
@@ -76,3 +81,20 @@ function __ObjCritPure(model::T,T̄,x,z) where T
     F2 = -∂³A∂V³*∂³A∂V³_scale
     return SVector((F1,F2))
 end
+
+"""
+    mechanical_critical_point(model,z = SA[1.0],x0 = x0_crit_pure(model,z))
+
+Returns the mechanical critical point of an `EoSModel`. The mechanical critical point is the point where the first and second derivatives of the pressure function vanish.
+For single component models, the function is equivalent to [`crit_pure`](@ref).
+Returns a tuple, containing:
+
+- Mechanical critical temperature `[K]`
+- Mechanical critical pressure `[Pa]`
+- Mechanical critical molar volume `[m³·mol⁻¹]`
+"""
+function mechanical_critical_point end
+
+mechanical_critical_point(model,z,x0) = crit_pure(model,x0,z)
+mechanical_critical_point(model,z) = mechanical_critical_point(model,z,x0_crit_pure(model,z))
+mechanical_critical_point(model) = crit_pure(model)

--- a/src/methods/property_solvers/singlecomponent/singlecomponent.jl
+++ b/src/methods/property_solvers/singlecomponent/singlecomponent.jl
@@ -29,8 +29,7 @@ function check_valid_eq2(model1,model2,p,V1,V2,T,ε0 = 5e7)
             _is_positive((p1,p2,V2,V2,T,p)) #positive and finite pressures and volumes
 end
 
-function μp_equality1_p(model1,model2,v1,v2,T,ps,μs)
-    z = SA[1.0]
+function μp_equality1_p(model1,model2,v1,v2,T,ps,μs,z = SA[1.0])
     RT = Rgas(model1)*T
     f1(V) = a_res(model1,V,T,z)
     f2(V) = a_res(model2,V,T,z)
@@ -43,13 +42,12 @@ function μp_equality1_p(model1,model2,v1,v2,T,ps,μs)
     return SVector(Fμ,Fp)
 end
 
-function μp_equality1_p(model,v1,v2,T) 
-    ps,μs = equilibria_scale(model)
-    μp_equality1_p(model,model,v1,v2,T,ps,μs)
+function μp_equality1_p(model,v1,v2,T,z = SA[1.0]) 
+    ps,μs = equilibria_scale(model,z)
+    μp_equality1_p(model,model,v1,v2,T,ps,μs,z)
 end
 
-function μp_equality1_T(model1,model2,v1,v2,p,T,ps,μs)
-    z = SA[1.0]
+function μp_equality1_T(model1,model2,v1,v2,p,T,ps,μs,z = SA[1.0])
     RT = Rgas(model1)*T
     f1(V) = a_res(model1,V,T,z)
     f2(V) = a_res(model2,V,T,z)
@@ -61,6 +59,11 @@ function μp_equality1_T(model1,model2,v1,v2,p,T,ps,μs)
     Fp1 = (p1 - p)*ps
     Fp2 = (p2 - p)*ps
     return SVector(Fμ,Fp1,Fp2)
+end
+
+function μp_equality1_T(model,v1,v2,p,T,z = SA[1.0]) 
+    ps,μs = equilibria_scale(model,z)
+    μp_equality1_T(model,model,v1,v2,p,T,ps,μs,z)
 end
 
 function try_2ph_pure_pressure(model,T,v10,v20,ps,mus,method)

--- a/src/methods/property_solvers/singlecomponent/singlecomponent.jl
+++ b/src/methods/property_solvers/singlecomponent/singlecomponent.jl
@@ -1,12 +1,12 @@
 """
-    check_valid_sat_pure(model,P_sat,Vl,Vv,T,ε0 = 5e7)
+    check_valid_sat_pure(model,P_sat,Vl,Vv,T,z = SA[1.0])
 
 Checks that a saturation method converged correctly. it checks:
 - That both volumes are mechanically stable
 - That both volumes are different, with a difference of at least `ε0` epsilons
 """
-function check_valid_sat_pure(model,P_sat,V_l,V_v,T,ε0 = 5e7)
-   return check_valid_eq2(model,model,P_sat,V_l,V_v,T,ε0)
+function check_valid_sat_pure(model,P_sat,V_l,V_v,T,z = SA[1.0])
+   return check_valid_eq2(model,model,P_sat,V_l,V_v,T,z)
 end
 
 _p∂p∂V(model,V,T,z,p) = p∂p∂V(model,V,T,z)
@@ -19,11 +19,11 @@ end
 _is_positive(x::Number) = isfinite(x) && x > zero(x)
 _is_positive(x::Tuple) = all(_is_positive,x)
 
-function check_valid_eq2(model1,model2,p,V1,V2,T,ε0 = 5e7)
+function check_valid_eq2(model1,model2,p,V1,V2,T,z = SA[1.0],ε0 = 5e7)
     ε = abs(V1-V2)/(eps(typeof(V1-V2)))
     ε <= ε0 && return false
-    p1,dpdv1 = _p∂p∂V(model1,V1,T,SA[1.0],p)
-    p2,dpdv2 = _p∂p∂V(model2,V2,T,SA[1.0],p)
+    p1,dpdv1 = _p∂p∂V(model1,V1,T,z,p)
+    p2,dpdv2 = _p∂p∂V(model2,V2,T,z,p)
     return  (dpdv1 <= 0)                    && #mechanical stability of phase 1
             (dpdv2 <= 0)                    && #mechanical stability of phase 2
             _is_positive((p1,p2,V2,V2,T,p)) #positive and finite pressures and volumes

--- a/src/methods/property_solvers/stability/stability.jl
+++ b/src/methods/property_solvers/stability/stability.jl
@@ -72,7 +72,7 @@ function VT_diffusive_eigvalue(model,V,T,z = SA[1.0])
 end
 
 """
-    diffusive_stability(model,p,T,z = SA[1.0],phase = :unknown,threaded = true,vol0 = nothing)
+    diffusive_stability(model,p,T,z = SA[1.0];phase = :unknown,threaded = true,vol0 = nothing)
 
 Performs a diffusive stability for a (V,T,z) pair, returns `true/false`.
 
@@ -81,7 +81,7 @@ Performs a diffusive stability for a (V,T,z) pair, returns `true/false`.
 The keywords `phase`, `threaded` and `vol0` are passed to the [`Clapeyron.volume`](@ref) solver.
 
 """
-function diffusive_stability(model,p,T,z = SA[1.0],phase = :unknown,threaded = true,vol0 = nothing)
+function diffusive_stability(model,p,T,z = SA[1.0];phase = :unknown,threaded = true,vol0 = nothing)
     V = volume(model,p,T,z;phase,threaded,vol0)
     return VT_diffusive_stability(model,V,T,z)
 end

--- a/src/models/EmpiricHelmholtz/MultiFluid/multifluid.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/multifluid.jl
@@ -207,6 +207,11 @@ function lb_volume(model::MultiFluid,z)
     return dot(z,model.params.lb_volume.values)
 end
 
+function x0_crit_pure(model::MultiFluid,z)
+    return (1.0,log10(v_scale(model,z)))
+end
+
+
 #use ideal gas
 #function x0_volume_gas(model::MultiFluid,p,T,z)
 #    

--- a/src/models/PeTS/PeTS.jl
+++ b/src/models/PeTS/PeTS.jl
@@ -115,7 +115,7 @@ const PeTS_B = (
 
 function lb_volume(model::PeTSModel,z)
     σ3,_,m̄ = σϵ_m_vdw1f(model,1.0,1.0,z)
-    return m̄*N_A*σ3*π/6
+    return sum(z)*m̄*N_A*σ3*π/6
 end
 
 function x0_volume_liquid(model::PeTSModel,T,z)
@@ -134,7 +134,8 @@ function T_scale(model::PeTSModel,z)
     return ϵ
 end
 
-function x0_crit_pure(model::PeTSModel)
-    lb_v = lb_volume(model)
+function x0_crit_pure(model::PeTSModel,z)
+    σ3,ϵ,m̄ = σϵ_m_vdw1f(model,1.0,1.0,z)
+    lb_v = m̄*N_A*σ3*π/6
     (1.08, log10(lb_v/0.32))
 end

--- a/src/models/SAFT/BACKSAFT/BACKSAFT.jl
+++ b/src/models/SAFT/BACKSAFT/BACKSAFT.jl
@@ -92,8 +92,9 @@ function x0_volume_liquid(model::BACKSAFTModel,T,z)
     return v_lb*1.01
 end
 
-function x0_crit_pure(model::BACKSAFTModel)
-    lb_v = lb_volume(model)
+function x0_crit_pure(model::BACKSAFTModel,z)
+    T = T_scale(model,z)
+    lb_v = lb_volume(model,T,z)/sum(z)
     (2.0, log10(lb_v/0.4))
 end
 

--- a/src/models/SAFT/CKSAFT/variants/sCKSAFT.jl
+++ b/src/models/SAFT/CKSAFT/variants/sCKSAFT.jl
@@ -66,8 +66,9 @@ Simplified Chen and Kreglewski SAFT (sCK-SAFT)
 """
 sCKSAFT
 
-function x0_crit_pure(model::sCKSAFTModel)
-    lb_v = lb_volume(model)
+function x0_crit_pure(model::sCKSAFTModel,z)
+    T = T_scale(model,z)
+    lb_v = lb_volume(model,T,z)/sum(z)
     res = (5.0, log10(lb_v/0.3))
     return res
 end

--- a/src/models/SAFT/CPA/CPA.jl
+++ b/src/models/SAFT/CPA/CPA.jl
@@ -261,10 +261,9 @@ function show_info(io,model::CPAModel)
     end
 end
 
-function x0_crit_pure(model::CPAModel)
-    z = SA[1.0]
+function x0_crit_pure(model::CPAModel,z)
     T = T_scale(model,z)
-    lb_v = lb_volume(model,T,z)
+    lb_v = lb_volume(model,T,z)/sum(z)
     return (1.0, log10(lb_v/0.3))
 end
 

--- a/src/models/SAFT/equations.jl
+++ b/src/models/SAFT/equations.jl
@@ -133,8 +133,9 @@ end
 # packing_fraction(model::MyModel,data::Tuple)
 # packing_fraction(model,data) = nothing
 
-function x0_crit_pure(model::SAFTModel)
-    lb_v = lb_volume(model)
+function x0_crit_pure(model::SAFTModel,z)
+    T = T_scale(model,z)
+    lb_v = lb_volume(model,T,z)/sum(z)
     (2.0, log10(lb_v/0.3))
 end
 

--- a/src/models/cubic/KU/KU.jl
+++ b/src/models/cubic/KU/KU.jl
@@ -199,8 +199,6 @@ function p_scale(model::KUModel,z)
     return dot(model.params.Pc.values,z)/sum(z)
 end
 
-function x0_crit_pure(model::KUModel)
-    lb_v = lb_volume(model,model.params.Tc[1],SA[1.0])
-    vc = model.params.Vc.values[1]
-    (1.1, log10(vc))
+function x0_crit_pure(model::KUModel,z)
+    (1.1, log10(dot(model.params.Vc.values,z)/sum(z)))
 end

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -576,14 +576,11 @@ function vdw_tv_mix(Tc,Vc,z)
 end
 
 function x0_crit_mix(model::CubicModel,z)
-    pure = split_pure_model(model)
-    crit = crit_pure.(pure)
-    vci = getindex.(crit,3)
     tci = model.params.Tc.values
     ∑z = sum(z)
     T_c  = prod(tci[i]^(z[i]/∑z) for i ∈ 1:length(model))
-
-
+    P_c = dot(model.params.Pc.values,z)/∑z
+    V_c = volume(model,P_c,T_c,z,phase = :v)/∑z
     return (log10(V_c),T_c)
 end
 antoine_coef(model::ABCubicModel) = (6.668322465137264,6.098791871032391,-0.08318016317721941)

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -288,6 +288,7 @@ function __crit_pure_Δ_obj(T,v,R,a,b,Δ1,Δ2)
 end
 
 function volume_impl(model::CubicModel,p,T,z,phase,threaded,vol0)
+    check_arraysize(model,z)
     lb_v = lb_volume(model,T,z)
     if iszero(p) && is_liquid(phase) #liquid root at zero pressure if available
         vl,_ = zero_pressure_impl(model,T,z)

--- a/src/models/cubic/equations.jl
+++ b/src/models/cubic/equations.jl
@@ -221,9 +221,9 @@ function p_scale(model::CubicModel, z)
     return dot(z, _pc) / sum(z)
 end
 
-function x0_crit_pure(model::CubicModel)
-    Tc = model.params.Tc.values[1]
-    lb_v = lb_volume(model,Tc,SA[1.0])    
+function x0_crit_pure(model::CubicModel,z)
+    Tc = T_scale(model,z)
+    lb_v = lb_volume(model,Tc,z)/sum(z)
     (1.0, log10(lb_v / 0.3))
 end
 
@@ -300,7 +300,7 @@ function volume_impl(model::CubicModel,p,T,z,phase,threaded,vol0)
     end
     nRTp = sum(z)*R̄*T/p
     _poly,c̄ = cubic_poly(model,p,T,z)
-   
+
     c = c̄*sum(z)
     num_isreal, z1, z2, z3 = Solvers.real_roots3(_poly)
     if num_isreal == 2
@@ -575,6 +575,17 @@ function vdw_tv_mix(Tc,Vc,z)
     return (Tcm,Vcm)
 end
 
+function x0_crit_mix(model::CubicModel,z)
+    pure = split_pure_model(model)
+    crit = crit_pure.(pure)
+    vci = getindex.(crit,3)
+    tci = model.params.Tc.values
+    ∑z = sum(z)
+    T_c  = prod(tci[i]^(z[i]/∑z) for i ∈ 1:length(model))
+
+
+    return (log10(V_c),T_c)
+end
 antoine_coef(model::ABCubicModel) = (6.668322465137264,6.098791871032391,-0.08318016317721941)
 
 

--- a/src/models/cubic/vdW/variants/Berthelot.jl
+++ b/src/models/cubic/vdW/variants/Berthelot.jl
@@ -169,8 +169,9 @@ function p_scale(model::BerthelotModel,z)
     dot(model.params.Pc.values,z)/sum(z)
 end
 
-function x0_crit_pure(model::BerthelotModel)
-    lb_v = lb_volume(model)
+function x0_crit_pure(model::BerthelotModel,z)
+    T = T_scale(model,z)
+    lb_v = lb_volume(model,T,z)
     (1.1, log10(lb_v*3))
 end
 

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -483,7 +483,7 @@ end
     @test saturation_temperature(cpr,crit_cpr[2] - 1e3)[1] ≈ 369.88681908031606 rtol = 1e-6
 end
 
-@testset "Tproperty" begin
+@testset "Tproperty/Property" begin
     model1 = cPR(["propane","dodecane"])
     p = 101325.0; T = 300.0;z = [0.5,0.5]
     h_ = enthalpy(model1,p,T,z)
@@ -525,6 +525,13 @@ end
     fluid409 = cPR(["Propane","R134a"],idealmodel=ReidIdeal);z409 = [1.0,1.0];
     s409 = -104.95768957075641; p409 = 5.910442025416817e6;
     @test Tproperty(fluid409,p409,s409,z409,entropy) ≈ 406.0506318701147 rtol = 1e-6
+
+    model5 = cPR(["R134a","propane"],idealmodel=ReidIdeal)
+    @test Clapeyron._Pproperty(model5,450.0,0.03,[0.5,0.5],volume)[2] == :vapour
+    @test Clapeyron._Pproperty(model5,450.0,0.03,[0.5,0.5],volume)[2] == :vapour
+    @test Clapeyron._Pproperty(model,450.0,0.00023,[0.5,0.5],volume)  == :eq
+    @test Clapeyron._Pproperty(model,450.0,0.000222,[0.5,0.5],volume)  == :eq
+    @test Clapeyron._Pproperty(model,450.0,0.000222,[0.5,0.5],volume)  == :eq
 end
 
 @testset "bubble/dew point algorithms" begin


### PR DESCRIPTION
This reimplements the `Tproperty`/`Tproperty` functions to calculate the edge point as the starting point.

## Algorithm
The new algorithm uses the following steps:

1. calculate edge point. if edge point is not feasible, reuse information from the failed edge point calc to obtain the mechanical critical point
2. if the property is inside the edge limits, return edge pressure/temperature
3. if the property is over the mechanical critical point, calculate the volume at specified property, compare with critical volume. calculate one bubble/dew to see if the property is between the critical volume and saturation volume. select the phase tag accordingly
4. if the edge calculation succeded and the property is at one side of the edge, calculate the corresponding bubble/dew property, select the phase tag accordingly

## Edges

This PR adds three new functions:
`edge_pressure(model,T,z)`: returns the edge pressure, liquid and vapour volumes
`edge_temperature(model,p,z)`: returns the edge temperature, liquid and vapour volumes
`mechanical_critical_point(model,z)`: mechanical critical point, where the edge vanishes.

Edge conditions are equivalent to the saturation conditions for single component models. and the mechanical critical point for single component models is equivalent to the critical point.

## performance:

For points between the edge limits, we save a lot of computation:

```julia
julia> model = cPR(["R134a","propane"],idealmodel=ReidIdeal);

julia> @time Clapeyron._Pproperty(model,320.0,0.0003,[0.5,0.5],volume)
  0.000213 seconds (279 allocations: 13.484 KiB)
(1.4084534385450277e6, :eq)
```
Even for points away from the edge, now we only need to perform 1 bubbledew, instead of two. and the initial point for bubbledew can be obtained by the initial point used for the edge calculation, so there are less allocations overall.

Based on [#428 ](https://github.com/ClapeyronThermo/Clapeyron.jl/issues/428#issuecomment-3213393315)

