### PR TITLE
Python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ LocalPreferences.toml
 /notebooks
 examples/Playground/*
 .DS_Store
+*.venv*
+*dist
+*.egg-info
+*build
+*__pycache__

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -41,6 +41,7 @@ warnonly = Documenter.except(),
                   "Macros" => "api/macros.md",
                   "Association" => "api/association.md",
                   "Parameter Estimation" => "api/estimation.md"],
+        "`pyclapeyron`" => "python.md",
         "To-do list" => "to-do_list.md"]
                   )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,6 +51,12 @@ Clapeyron.jl is a registered package, it can be installed from the general regis
 pkg> add Clapeyron
 ```
 
+## Usage from Python
+
+`Clapeyron.jl` can also be used from Python via [`juliacall`](https://juliapy.github.io/PythonCall.jl/stable/juliacall/).
+Therefore, a python package named `pyclapeyron` can be installed via `pip`, i.e. `pip install pyclapeyron`.
+A detailed description of the `pyclapeyron` package is given in [Python package `pyclapeyron`](@ref).
+
 ## Citing `Clapeyron.jl`
 
 If you are using Clapeyron for your research work, please cite the following:

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -1,0 +1,37 @@
+# Python package `pyclapeyron`
+
+`pyclapeyron` exposes the functionality of `Clapeyron.jl` to Python via [`juliacall`](https://juliapy.github.io/PythonCall.jl/stable/juliacall/), which provides the bridge to Julia under the hood. Unless otherwise noted, the public Python API mirrors the Julia API described in this documentation.
+
+## Installation
+
+Install from PyPI:
+
+```
+pip install pyclapeyron
+```
+
+## Example
+
+```python
+import pyclapeyron as cl
+import numpy as np
+
+pure = cl.SAFTVRMie("butanol")
+
+Tc, pc, vc = cl.crit_pure(pure)
+pv, vl, vv = cl.saturation_pressure(pure, 400)
+
+rhol = cl.molar_density(pure, pv, 400, phase="liquid")
+rhov = cl.molar_density(pure, pv, 400, phase="vapour")
+
+mix = cl.PCSAFT(["propane", "ethanol"])
+pv, vl, vv, _y = cl.bubble_pressure(mix, 300, np.array([0.5,0.5]))
+y = np.array(_y)
+```
+
+## Notes & limitations
+
+- Inputs: arrays passed to `Clapeyron.jl` functions must be NumPy arrays.
+- Outputs: returned arrays are `juliacall` array objects; they can be converted to NumPy arrays with `np.array(...)` (see example above).
+- Julia macros and mutating (in-place, `!`) functions are not directly callable from Python.
+- Please report any issues on the `Clapeyron.jl` GitHub repository.

--- a/pyclapeyron/__init__.py
+++ b/pyclapeyron/__init__.py
@@ -1,0 +1,9 @@
+from juliacall import Main as jl
+
+jl.seval("using Clapeyron")
+
+for n in jl.names(jl.Clapeyron):
+    s = str(n)
+    valid = not s[0] == '@' and not s[-1] == '!'
+    if valid:
+        exec(f'{n} = jl.{n}')

--- a/pyclapeyron/juliapkg.json
+++ b/pyclapeyron/juliapkg.json
@@ -1,0 +1,9 @@
+{
+    "julia": "1.10",
+    "packages": {
+        "Clapeyron": {
+            "uuid": "7c7805af-46cc-48c9-995b-ed0ed2dc909a",
+            "version": "0.6.16"
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyclapeyron"
+version = "0.1.0"
+description = "Python bindings for the Julia package Clapeyron.jl"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "juliacall>=0.9",
+]
+authors = [
+  { name = "Your Name", email = "you@example.com" }
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["pyclapeyron*"]
+
+[tool.setuptools.package-data]
+pyclapeyron = ["juliapkg.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
     "juliacall>=0.9",
 ]
 authors = [
-  { name = "Your Name", email = "you@example.com" }
+  { name = "Hon Wa Yew", email = "yewhonwa@gmail.com" },
+  { name = "Pierre Walker", email = "pjwalker@caltech.edu" },
+  { name = "Andrés Riedemann", email = "andres.riedemann@gmail.com" }
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
I added some files to make Clapeyron.jl accessible from Python through juliacall. The idea is to create a PyPi package (named `pyclapeyron` that is installable with `pip`) and ease the access to Clapeyron for Python users. 

This PR is meant to be a basis for discussion and only implements one option. It adds the following files:
- `__init__.py`: the "actual python module" - it just adds all exported functions from Clapeyron and adds them to the module namespace (otherwise, everything would be living in the jl module). This is the simplest approach without writing much Python code and thus having two documentations etc. (e.g. the "Julia" docu is also valid for the python frontend). This comes with some drawbacks related to special type conversions (e.g. input arrays need to be np arrays, output arrays need to be converted).
- `juliapkg.json`: This file just contains the julia dependencies (only Clapeyron) and allows restricting the version.
- `pyproject.toml`: Python project file

I also added some docs with an example. The Python package can be build with `python -m build` (in the Clapeyron folder) and then being installed by `pip install dist/pyclapeyron-0.1.0-py3-none-any.whl`.

```python
import pyclapeyron as cl
import numpy as np

pure = cl.SAFTVRMie("butanol")

Tc, pc, vc = cl.crit_pure(pure)
pv, vl, vv = cl.saturation_pressure(pure, 400)

rhol = cl.molar_density(pure, pv, 400, phase="liquid")
rhov = cl.molar_density(pure, pv, 400, phase="vapour")

mix = cl.PCSAFT(["propane", "ethanol"])
pv, vl, vv, _y = cl.bubble_pressure(mix, 300, np.array([0.5,0.5]))
y = np.array(_y)
```

The actual registering at PyPi could be done using GitHub actions and being triggered for every new version of Clapeyron (to make both packages have the same version). I found an example e.g. [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).

However, this would be only one option - others would be:

- A "light" alternative: Just adding a section to the docs where using Clapeyron through `juliacall` is being explained. But this would be a much higher barrier to use Clapeyron from Python compared to `pip install ...`.
- A "comprehensive" alternative: Defining new API functions in the Python package that handle type conversion etc (that would be more work for implementing and maintaining).

What's your opinion on this? 

I think it would be nice to have such an interface to Python and it would make the nice models and methods available for a broader  use base.