### PR TITLE
added `moles_positivity` for `Real` inputs

### DIFF
--- a/src/base/errors.jl
+++ b/src/base/errors.jl
@@ -83,3 +83,7 @@ end
 function moles_positivity(x::AbstractVector{T}) where T<:Real
     @assert all(>=(0), x) "Mole vector contains non-positive values! Contains values $x"
 end
+
+function moles_positivity(x::T) where T<:Real
+    @assert x >= 0 "Moles non-positive values! Contains values $x"
+end


### PR DESCRIPTION
Hello,

Here I add another dispatch for `moles_positivity` for when input is non-vector. In ref to #457.

The following will work in this PR:

```julia
julia> using Clapeyron

julia> mod_H2O_pr = PR(["water"]);

julia> T = 80 + 273.15;

julia> bubble_pressure(mod_H2O_pr,T,1)
(43987.666751092685, 2.2280375877369628e-5, 0.06645941977413594, 1.0)
``` 