### PR TITLE
Add link to Electrolyte Models documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,7 @@ warnonly = Documenter.except(),
                             "Activity Models" => "eos/activity.md"
                             "SAFT and CPA Models"  => "eos/saft.md"
                             "Empiric Helmholtz Models" => "eos/empiric.md"
+                            "Electrolyte Models" => "eos/electrolytes.md"
                             "Property Correlations" =>  "eos/correlations.md"
                             "Other Models" => "eos/misc.md"],
         "Frequently Asked Questions" => "faq.md",


### PR DESCRIPTION
Are the electrolyte models missing in the list of models? One can search them but in the docs but they don't appear in the list of models and there is no title (see screenshot).
<img width="1157" height="732" alt="Bildschirmfoto vom 2025-11-27 13-07-17" src="https://github.com/user-attachments/assets/54da4caa-f4fa-466f-a5ed-b228ee150dce" />
