### PR TITLE
Doc audit: fill API gaps and add alias doc forwarding

### DIFF
--- a/docs/src/api/estimation.md
+++ b/docs/src/api/estimation.md
@@ -22,4 +22,5 @@ Clapeyron.Estimation
 Clapeyron.EstimationData
 Clapeyron.return_model
 Clapeyron.objective_function
+Clapeyron.update_estimation!
 ```

--- a/docs/src/api/parameters.md
+++ b/docs/src/api/parameters.md
@@ -31,6 +31,8 @@ Clapeyron.cleartemp!
 ## Parameter types
 
 ```@docs
+Clapeyron.EoSParam
+Clapeyron.ParametricEoSParam
 Clapeyron.SingleParam
 Clapeyron.PairParam
 Clapeyron.AssocParam
@@ -67,12 +69,29 @@ Clapeyron.lambda_LorentzBerthelot!
 Clapeyron.lambda_squarewell!
 ```
 
+## Binary interaction parameters
+
+```@docs
+Clapeyron.get_k
+Clapeyron.get_l
+Clapeyron.set_k!
+Clapeyron.set_l!
+```
+
 ## Group Combining Rules
 
 ```@docs
 Clapeyron.group_sum
+Clapeyron.group_sum!
 Clapeyron.group_pairmean
+Clapeyron.group_pairmean!
 Clapeyron.group_matrix
+```
+
+## Group Segment Cache Types
+
+```@docs
+Clapeyron.MixedGCSegmentParam
 ```
 
 ## Model Splitting

--- a/docs/src/dev.md
+++ b/docs/src/dev.md
@@ -19,3 +19,9 @@
 ### Group Parameters
 
 ## `split_model` and `index_reduction`
+
+## Precompilation
+
+```@docs
+Clapeyron.precompile_clapeyron!
+```

--- a/docs/src/eos/activity.md
+++ b/docs/src/eos/activity.md
@@ -30,11 +30,13 @@ In this case, those potentials are dependent of the pressure, whereas activity m
 
 ```@docs
 Clapeyron.FloryHuggins
+Clapeyron.FH
 Clapeyron.Margules
 Clapeyron.VanLaar
 Clapeyron.Wilson
 Clapeyron.tcPRWilsonRes
 Clapeyron.NRTL
+Clapeyron.eNRTL
 Clapeyron.aspenNRTL
 Clapeyron.UNIQUAC
 ```

--- a/docs/src/eos/correlations.md
+++ b/docs/src/eos/correlations.md
@@ -53,6 +53,7 @@ YamadaGunnLiquid
 COSTALD
 GrenkeElliottWater
 HoltenWater
+ZeroLiquid
 ```
 
 # Virial Models

--- a/docs/src/eos/cubic.md
+++ b/docs/src/eos/cubic.md
@@ -111,8 +111,10 @@ Clapeyron.sCPAAlpha
 Clapeyron.MTAlpha
 Clapeyron.BMAlpha
 Clapeyron.TwuAlpha
+Clapeyron.Twu91Alpha
 Clapeyron.Twu88Alpha
 Clapeyron.PatelTejaAlpha
+Clapeyron.PTVAlpha
 Clapeyron.KUAlpha
 Clapeyron.RKPRAlpha
 Clapeyron.LeiboviciAlpha
@@ -124,7 +126,9 @@ Clapeyron.LeiboviciAlpha
 Clapeyron.translation
 Clapeyron.NoTranslation
 Clapeyron.ConstantTranslation
+Clapeyron.ClausiusTranslation
 Clapeyron.PenelouxTranslation
+Clapeyron.RackettTranslation
 Clapeyron.TVTPRTranslation
 Clapeyron.MTTranslation
 ```

--- a/docs/src/eos/empiric.md
+++ b/docs/src/eos/empiric.md
@@ -88,6 +88,8 @@ Clapeyron.GERG2008
 Clapeyron.EOS_LNG
 Clapeyron.EOS_CG
 Clapeyron.HelmAct
+Clapeyron.TillnerRothFriend
+Clapeyron.TillnerRothModel
 ```
 
 ## Mixing Models

--- a/docs/src/eos/ideal.md
+++ b/docs/src/eos/ideal.md
@@ -28,4 +28,12 @@ Clapeyron.WalkerIdeal
 Clapeyron.LJRefIdeal
 Clapeyron.AlyLeeIdeal
 Clapeyron.PPDSIdeal
+Clapeyron.ShomateIdeal
+Clapeyron.CPLNGEstIdeal
+```
+
+## Joback GC Utilities
+
+```@docs
+Clapeyron.JobackGC
 ```

--- a/docs/src/eos/misc.md
+++ b/docs/src/eos/misc.md
@@ -15,12 +15,15 @@ Clapeyron.ECS
 Clapeyron.shape_factors
 Clapeyron.SPUNG
 Clapeyron.LKP
+Clapeyron.LKPSJT
+Clapeyron.enhancedLKP
 ```
 
 ## Sanchez–Lacombe Model
 
 ```@docs
 Clapeyron.SanchezLacombe
+Clapeyron.SL
 Clapeyron.mix_vε
 Clapeyron.SLKRule
 Clapeyron.SLk0k1lMixingRule
@@ -30,4 +33,13 @@ Clapeyron.SLk0k1lMixingRule
 
 ```@docs
 Clapeyron.PeTS
+```
+
+# Composite and Utility Models
+
+```@docs
+Clapeyron.CompositeModel
+Clapeyron.FluidCorrelation
+Clapeyron.GammaPhi
+Clapeyron.ZeroResidual
 ```

--- a/docs/src/eos/saft.md
+++ b/docs/src/eos/saft.md
@@ -29,11 +29,15 @@ Clapeyron.iPCSAFT
 
 ```@docs
 Clapeyron.SAFTVRMie
+Clapeyron.SAFTVRMieGV
 Clapeyron.SAFTVRMie15
 Clapeyron.SAFTVRQMie
 Clapeyron.SAFTVRSMie
 Clapeyron.SAFTgammaMie
+Clapeyron.SAFTγMie
 Clapeyron.structSAFTgammaMie
+Clapeyron.sSAFTgammaMie
+Clapeyron.sSAFTγMie
 Clapeyron.SAFTVRSW
 ```
 

--- a/docs/src/properties/basic.md
+++ b/docs/src/properties/basic.md
@@ -23,6 +23,16 @@ Clapeyron.eos
 Clapeyron.eos_res
 Clapeyron.idealmodel
 Clapeyron.a_res
+Clapeyron.eosshow
+```
+
+## Core types and utilities
+
+```@docs
+Clapeyron.EoSModel
+Clapeyron.Rgas
+Clapeyron.has_groups
+Clapeyron.has_sites
 ```
 
 ## Automatic Differentiation functions
@@ -56,4 +66,5 @@ Clapeyron.TPFlashMethod
 Clapeyron.ReferenceState
 Clapeyron.reference_state
 Clapeyron.has_reference_state
+Clapeyron.set_reference_state!
 ```

--- a/docs/src/properties/bulk.md
+++ b/docs/src/properties/bulk.md
@@ -63,6 +63,7 @@ Clapeyron.gibbs_free_energy_res
 Clapeyron.entropy
 Clapeyron.entropy_res
 Clapeyron.enthalpy
+Clapeyron.enthalpy_res
 Clapeyron.internal_energy
 Clapeyron.internal_energy_res
 ```
@@ -99,6 +100,7 @@ Clapeyron.reference_chemical_potential_type
 
 ```@docs
 Clapeyron.mixing
+Clapeyron.excess
 Clapeyron.partial_property
 Clapeyron.shape_factors
 Clapeyron.thermodynamic_factor

--- a/docs/src/properties/multi.md
+++ b/docs/src/properties/multi.md
@@ -43,11 +43,14 @@ Clapeyron.crit_mix
 Clapeyron.mechanical_critical_point
 Clapeyron.spinodal_pressure
 Clapeyron.spinodal_temperature
+Clapeyron.spinodal_maximum
 Clapeyron.edge_pressure
 Clapeyron.edge_temperature
 Clapeyron.UCEP_mix
 Clapeyron.UCST_pressure
 Clapeyron.UCST_temperature
+Clapeyron.UCST_mix
+Clapeyron.krichevskii_parameter
 ```
 
 ## SLE Equilibria
@@ -107,10 +110,12 @@ Clapeyron.supports_reduction
 Clapeyron.FlashResult
 Clapeyron.FlashData
 Clapeyron.FlashSpecifications
+Clapeyron.RRQXFlash
 Clapeyron.xy_flash
 Clapeyron.GeneralizedXYFlash
 Clapeyron.ph_flash
 Clapeyron.ps_flash
+Clapeyron.uv_flash
 Clapeyron.qt_flash
 Clapeyron.qp_flash
 Clapeyron.ts_flash

--- a/docs/src/properties/single.md
+++ b/docs/src/properties/single.md
@@ -18,6 +18,7 @@ Pages = ["single.md"]
 
 ```@docs
 Clapeyron.saturation_pressure
+Clapeyron.saturation_liquid_density
 Clapeyron.saturation_temperature
 Clapeyron.enthalpy_vap
 Clapeyron.crit_pure
@@ -42,4 +43,16 @@ Clapeyron.ChemPotDensitySaturation
 Clapeyron.IsoFugacitySaturation
 Clapeyron.ClapeyronSaturation
 Clapeyron.AntoineSaturation
+Clapeyron.CritExtrapolationSaturation
+Clapeyron.SuperAncSaturation
+Clapeyron.use_superancillaries!
+```
+
+## Widom and CIIC loci
+
+```@docs
+Clapeyron.widom_pressure
+Clapeyron.widom_temperature
+Clapeyron.ciic_pressure
+Clapeyron.ciic_temperature
 ```

--- a/src/base/EoSModel.jl
+++ b/src/base/EoSModel.jl
@@ -154,6 +154,15 @@ macro comps()
     end |> esc
 end
 
+"""
+    has_sites(model::EoSModel)
+    has_sites(::Type{<:EoSModel})
+
+Returns `true` when a model type carries site parameters.
+
+This checks whether the model type has a `sites` field with `SiteParam`
+storage and is used to enable site-based logic (e.g. association models).
+"""
 has_sites(::T) where T <: EoSModel = has_sites(T)
 has_sites(::Type{T}) where T <: EoSModel = _has_sites(T)
 
@@ -165,6 +174,15 @@ Base.@assume_effects :foldable function _has_sites(::Type{T}) where T <: EoSMode
     return false
 end
 
+"""
+    has_groups(model::EoSModel)
+    has_groups(::Type{<:EoSModel})
+
+Returns `true` when a model type carries group parameters.
+
+This checks whether the model type has a `groups` field with `GroupParam`
+storage and is used to enable group-contribution logic.
+"""
 has_groups(::T) where T <: EoSModel = has_groups(T)
 has_groups(::Type{T}) where T <: EoSModel = _has_groups(T)
 

--- a/src/base/eosshow.jl
+++ b/src/base/eosshow.jl
@@ -8,7 +8,7 @@ custom_show(model::EoSModel) = _custom_show(model)
 custom_show(model) = false
 function _custom_show(Base.@nospecialize(model))
     hasfield(typeof(model),:components)
-end 
+end
 
 #function used to customize the first line to your liking
 show_info(io,model) = nothing
@@ -25,7 +25,7 @@ end
 
 function may_show_references(io::IO,model)
     if get(ENV,"CLAPEYRON_SHOW_REFERENCES","FALSE") == "TRUE"
-        show_references(io,model)     
+        show_references(io,model)
     end
 end
 
@@ -33,14 +33,24 @@ function show_references(io::IO,model)
     citations = cite(model)
     iszero(length(citations)) && return nothing #do not do anything if there isnt any citations
     println(io)
-    print(io,"References: ") 
+    print(io,"References: ")
     for (i,doi) in enumerate(cite(model))
         i != 1 && print(io,", ")
-        print(io,doi)   
+        print(io,doi)
     end
 end
 
-function eosshow(io::IO, mime::MIME"text/plain", Base.@nospecialize(model::EoSModel))   
+"""
+    eosshow(io::IO, model::EoSModel)
+    eosshow(io::IO, ::MIME"text/plain", model::EoSModel)
+
+Custom pretty-printer for `EoSModel` instances.
+
+This is the backend used by `Base.show` for models that opt into the custom
+display. The text/plain variant prints components, parameters, reference state,
+and (optionally) citations when enabled via `ENV["CLAPEYRON_SHOW_REFERENCES"]`.
+"""
+function eosshow(io::IO, mime::MIME"text/plain", Base.@nospecialize(model::EoSModel))
     print(io, typeof(model))
     if hasfield(typeof(model),:components)
         length(model) == 1 && println(io, " with 1 component:")
@@ -179,7 +189,7 @@ function eos_repr(io::IO,model;inside = false,newlines = true)
         k != nf && print(io,", ")
     end
     print(io,")")
-    
+
 
     return nothing
 end

--- a/src/database/ClapeyronParam.jl
+++ b/src/database/ClapeyronParam.jl
@@ -11,8 +11,13 @@ Abstract type corresponding to a container of `ClapeyronParam`s.
 It supposes that all fields are `ClapeyronParam`s.
 """
 abstract type EoSParam end
-abstract type ParametricEoSParam{T} <: EoSParam end
 
+"""
+    ParametricEoSParam{T} <: EoSParam
+
+Abstract type for parameter containers parameterized by element type `T`.
+"""
+abstract type ParametricEoSParam{T} <: EoSParam end
 
 """
     OptionsParam <: ClapeyronParam

--- a/src/database/combiningrules/group.jl
+++ b/src/database/combiningrules/group.jl
@@ -24,6 +24,13 @@ function _group_sum!(out,groups,param::Number)
     return out
 end
 
+"""
+    group_sum!(out, groups, param)
+
+In-place version of [`group_sum`](@ref). Fills `out` with the component
+values computed from group data. `out` can be a parameter container or a
+plain vector/matrix.
+"""
 function group_sum!(out::Union{SingleParameter,PairParameter},groups,param::SingleParameter)
     _group_sum!(diagvalues(out.values),groups,param)
     v = __get_group_sum_values(groups)
@@ -178,6 +185,12 @@ function group_pairmean(f::F,groups,p::AbstractArray) where {F}
     return group_pairmean!(res,f,groups,p)
 end
 
+"""
+    group_pairmean!(res, f, groups, param)
+
+In-place version of [`group_pairmean`](@ref). Writes the component-level
+values into `res`, using the mixing function `f` when `param` is a vector.
+"""
 function group_pairmean!(res,f::F,groups,param::SingleOrPair) where {F}
     return group_pairmean!(res,f,groups,param.values)
 end

--- a/src/database/params/GroupParam.jl
+++ b/src/database/params/GroupParam.jl
@@ -227,6 +227,15 @@ end
 
 #struct for n_groups_cache
 
+"""
+    MixedGCSegmentParam{T} <: ClapeyronParam
+
+Packed group/segment parameter container used by GC models.
+
+This type stores a compressed representation of group counts and segment
+information to speed up group-combining operations. It is typically created
+from a `GroupParam` via `MixedGCSegmentParam(group, ...)`.
+"""
 struct MixedGCSegmentParam{T} <: ClapeyronParam
     name::String
     components::Array{String,1}

--- a/src/database/params/ReferenceState.jl
+++ b/src/database/params/ReferenceState.jl
@@ -235,6 +235,16 @@ function has_reference_state_type(::Type{model}) where model
     return false
 end
 
+"""
+    set_reference_state!(model::EoSModel; verbose=false)
+    set_reference_state!(model, new_ref; verbose=false)
+
+Initialize and apply a reference state for `model`.
+
+When a `ReferenceState` is provided, it is initialized (if needed) and then
+applied to the model. For mixtures, this may trigger per-component reference
+state initialization via `split_pure_model`.
+"""
 function set_reference_state!(model::EoSModel;verbose = false)
     ref = reference_state(model)
     return set_reference_state!(model,ref;verbose = false)

--- a/src/methods/pT.jl
+++ b/src/methods/pT.jl
@@ -933,6 +933,15 @@ function mixing(model::EoSModel, p, T, z, property::ℜ; phase=:unknown, threade
     return mix_prop::TT
 end
 
+"""
+    excess(model::EoSModel, p, T, z, property; phase=:unknown, threaded=true, vol0=nothing)
+
+Returns the excess value of a bulk property relative to its ideal mixing value.
+
+By default this delegates to [`mixing`](@ref). For some properties (e.g.
+`entropy` and `gibbs_free_energy`) specialized implementations are provided to
+use residual contributions.
+"""
 function excess(model::EoSModel, p, T, z, property; phase=:unknown, threaded=true, vol0=nothing)
     mixing(model, p, T, z, property; phase, threaded, vol0)
 end

--- a/src/models/Activity/FH/FH.jl
+++ b/src/models/Activity/FH/FH.jl
@@ -16,6 +16,7 @@ struct FloryHuggins{c<:EoSModel} <: FloryHugginsModel
 end
 
 const FH = FloryHuggins
+@doc (@doc FloryHuggins) FH
 export FH, FloryHuggins
 
 """

--- a/src/models/Activity/NRTL/variants/eNRTL.jl
+++ b/src/models/Activity/NRTL/variants/eNRTL.jl
@@ -10,12 +10,26 @@ struct eNRTL{T<:IdealModel,c<:EoSModel,i<:IonModel} <: eNRTLModel
     ionmodel::i
     references::Array{String,1}
 end
-function eNRTL(solvents,ions; 
+
+"""
+    eNRTL(solvents, ions;
+        idealmodel = BasicIdeal,
+        neutralmodel = NRTL,
+        ionmodel = PDH,
+        RSPmodel = ConstRSP,
+        userlocations = String[],
+        ideal_userlocations = String[],
+        verbose = false)
+
+Electrolyte NRTL activity model. Builds a combined model for solvent and ion
+components using a neutral NRTL model and a selected ion model.
+"""
+function eNRTL(solvents,ions;
     idealmodel = BasicIdeal,
     neutralmodel = NRTL,
     ionmodel = PDH,
     RSPmodel = ConstRSP,
-    userlocations=String[], 
+    userlocations=String[],
     ideal_userlocations=String[],
      verbose=false)
     components = deepcopy(ions)
@@ -52,13 +66,13 @@ function excess_g_local(model::eNRTLModel, V, T, z)
     n = sum(z)
     invn = 1/n
     invT = 1/(T)
-    res = _0 
+    res = _0
 
 
     isolv = model.icomponents[model.charge.==0]
     icat = model.icomponents[model.charge.>0]
     iani = model.icomponents[model.charge.<0]
-    
+
     Ya = z[iani]
     Ya ./= sum(Ya)
 

--- a/src/models/EmpiricHelmholtz/LKP/variants/LKPSJT.jl
+++ b/src/models/EmpiricHelmholtz/LKP/variants/LKPSJT.jl
@@ -109,6 +109,7 @@ model = LKPSJT(["neon","hydrogen"];
 """
 LKPSJT
 const enhancedLKP = LKPSJT
+@doc (@doc LKPSJT) enhancedLKP
 
 function LKPSJT(components;
     idealmodel = BasicIdeal,

--- a/src/models/EmpiricHelmholtz/MultiFluid/variants/TillnerRothFriend.jl
+++ b/src/models/EmpiricHelmholtz/MultiFluid/variants/TillnerRothFriend.jl
@@ -42,5 +42,6 @@ function TillnerRothFriend(components = ["water","ammonia"],
 end
 
 const TillnerRothModel = MultiFluid{EmpiricAncillary, TillnerRothFriendMixing, TillnerRothFriendDeparture}
+@doc (@doc TillnerRothFriend) TillnerRothModel
 
 export TillnerRothFriend,TillnerRothModel

--- a/src/models/LatticeFluid/SanchezLacombe/SanchezLacombe.jl
+++ b/src/models/LatticeFluid/SanchezLacombe/SanchezLacombe.jl
@@ -59,6 +59,7 @@ aᵣ = r̄*(- ρ̃ /T̃ + (1/ρ̃  - 1)*log(1 - ρ̃ ) + 1)
 SanchezLacombe
 
 const SL = SanchezLacombe
+@doc (@doc SanchezLacombe) SL
 
 function SanchezLacombe(components;
     idealmodel = BasicIdeal,

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie.jl
@@ -216,6 +216,7 @@ mw(model::SAFTgammaMieModel) = mw(model.vrmodel)
 molecular_weight(model::SAFTgammaMieModel,z) = molecular_weight(model.vrmodel,z)
 
 const SAFTγMie = SAFTgammaMie
+@doc (@doc SAFTgammaMie) SAFTγMie
 export SAFTgammaMie,SAFTγMie
 
 SAFTVRMie(model::SAFTgammaMieModel) = model.vrmodel

--- a/src/models/SAFT/SAFTgammaMie/SAFTgammaMie_old.jl
+++ b/src/models/SAFT/SAFTgammaMie/SAFTgammaMie_old.jl
@@ -14,6 +14,7 @@ abstract type SAFTgammaMieModel <: GCSAFTModel end
 @newmodelgc SAFTgammaMie SAFTgammaMieModel SAFTgammaMieParam
 
 const SAFTγMie = SAFTgammaMie
+@doc (@doc SAFTgammaMie) SAFTγMie
 export SAFTgammaMie,SAFTγMie
 function SAFTgammaMie(components;
     idealmodel = BasicIdeal, userlocations = String[], ideal_userlocations = String[], verbose = false)

--- a/src/models/SAFT/SAFTgammaMie/variants/structSAFTgammaMie.jl
+++ b/src/models/SAFT/SAFTgammaMie/variants/structSAFTgammaMie.jl
@@ -113,7 +113,9 @@ function structSAFTgammaMie(components;
 end
 
 const sSAFTγMie = structSAFTgammaMie
+@doc (@doc structSAFTgammaMie) sSAFTγMie
 const sSAFTgammaMie = structSAFTgammaMie
+@doc (@doc structSAFTgammaMie) sSAFTgammaMie
 
 export structSAFTgammaMie,sSAFTgammaMie,sSAFTγMie
 

--- a/src/models/cubic/alphas/Twu.jl
+++ b/src/models/cubic/alphas/Twu.jl
@@ -56,6 +56,7 @@ alpha = TwuAlpha(["neon","hydrogen"];
 TwuAlpha
 
 const Twu91Alpha = TwuAlpha
+@doc (@doc TwuAlpha) Twu91Alpha
 
 """
     Twu88Alpha::TwuAlpha

--- a/src/models/cubic/translation/Peneloux.jl
+++ b/src/models/cubic/translation/Peneloux.jl
@@ -59,6 +59,7 @@ translation = PenelouxTranslation(["neon","hydrogen"];userlocations = (;Vc = [4.
 PenelouxTranslation
 
 const RackettTranslation = PenelouxTranslation
+@doc (@doc PenelouxTranslation) RackettTranslation
 
 export PenelouxTranslation
 export RackettTranslation #for compatibility


### PR DESCRIPTION
## Summary
- Filled documentation gaps across properties, EOS, API, and dev pages.
- Added doc forwarding for `const X = Y` aliases using `@doc (@doc Y) X`.
- Added core helper docstrings: `eosshow`, `excess`, `group_sum!`, `group_pairmean!`, `has_groups`, `has_sites`, `set_reference_state!`.

## Deprecated (Excluded)
- `PPCSAFT` (deprecated binding to `PCPSAFT`).

## Aliases Documented via `@doc` Forwarding
- `SAFTγMie` -> `SAFTgammaMie` (saft)
- `sSAFTgammaMie`, `sSAFTγMie` -> `structSAFTgammaMie` (saft)
- `Twu91Alpha` -> `TwuAlpha` (cubic)
- `enhancedLKP` -> `LKPSJT` (misc)
- `RackettTranslation` -> `PenelouxTranslation` (cubic)
- `SL` -> `SanchezLacombe` (misc)
- `FH` -> `FloryHuggins` (activity)
- `TillnerRothModel` -> `TillnerRothFriend` (empiric)

## Missing Docstrings (author to fill)
These exports still lack docstrings and were intentionally not documented to avoid inaccuracies.
I recommend the author completes these docs directly:

- `AnalyticalSLV`
- `CPATranslation`
- `DIPPR105Liquid`
- `EmpiricAncillary`
- `ExtendedCorrespondingStates`
- `LKPmod`
- `PolExpLiquid` / `PolExpVapour` / `PolExpSat`
- `gcPCSAFT` / `gcPCPSAFT`
- `hsdDH` / `MSAID` / `MM1`
- `TillnerRothFriendMixing` / `TillnerRothFriendDeparture`
- `YFRAlpha`
