### PR TITLE
Exclude tpflash TeX docs from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/tpflash/**/*.tex linguist-detectable=false


### PR DESCRIPTION
This PR marks *.tex as non-detectable in .gitattributes so GitHub Linguist reports Clapeyron as a 100% Julia repository.