### PR TITLE
Second attempt to fully exclude tpflash TeX files from Linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-test/tpflash/**/*.tex linguist-detectable=false
+test/tpflash/*.tex linguist-generated=true


### PR DESCRIPTION
This PR is a follow-up attempt to remove the remaining TeX share (0.1%).