### PR TITLE
XY flash via successive substitution

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ format = Documenter.HTML(
     # Use clean URLs, unless built as a "local" build
     canonical = "https://ClapeyronThermo.github.io/Clapeyron.jl/",
     assets = ["assets/logo.ico"],
+    size_threshold = 300_000,
 ),
 warnonly = Documenter.except(),
     authors = "Pierre J. Walker, Hon Wa Yew and Andrés Riedemann.",

--- a/docs/src/eos/cubic.md
+++ b/docs/src/eos/cubic.md
@@ -84,7 +84,7 @@ Clapeyron.QCPR
 
 ```@docs
 Clapeyron.PatelTeja
-Clapeyron.PatelTejaHayen
+Clapeyron.PatelTejaHeyen
 Clapeyron.PTV
 Clapeyron.YFR
 ```
@@ -119,7 +119,7 @@ Clapeyron.KU
 | **`RKPRAlpha`** | — | `RKPR` | Yes (estimated)² | Yes (estimated)² | Yes (estimated)², specific correlation for `RKPR`|
 | **`KUAlpha`** | Soave-ish (with extrapolation when T > Tc) | `KU` | No³ | No³ | No³ |
 | **`YFRAlpha`** | — | `YFR` | No³ | No³ | specific correlation for `YFR` |
-| **`PTHAlpha`** | — | `PatelTejaHayen` (only) | No³ | No³ | specific correlation for `PatelTejaHayen` |
+| **`PTHAlpha`** | — | `PatelTejaHeyen` (only) | No³ | No³ | specific correlation for `PatelTejaHeyen` |
 | **`MathiasCopemanAlpha`** | Mathias-Copeman | None | Only with custom params | Only with custom params | Only with custom params |
 | **`MC3PRAlpha`** | Mathias-Copeman | Provides estimation for PR | Yes (estimated) | Only with custom params | Only with custom params |
 | **`CPAAlpha`** / `sCPAAlpha` | Soave | CPA, sCPA | Only with custom params | Only with custom params | Only with custom params |
@@ -130,7 +130,7 @@ Clapeyron.KU
 
 2. **`LeiboviciAlpha`** is a unified Soave-type model that generates the `m(ω)` parameter based on the specific cubic EoS constants `Δ₁` and `Δ₂`. Consequently, it can be used with **any** cubic equation of state without requiring EoS-specific parameter correlations. Because of its generality, this model is used to provide estimation schemes for some alpha functions.
 
-3. **Model-Specific Alphas**: `KUAlpha`, `YFRAlpha`, and `PTHAlpha` are tightly coupled to their respective EoS (`KU`, `YFR`, `PatelTejaHayen`) with unique functional forms and/or parameter correlations. They are not designed or documented for use with PR, RK, or other cubic families.
+3. **Model-Specific Alphas**: `KUAlpha`, `YFRAlpha`, and `PTHAlpha` are tightly coupled to their respective EoS (`KU`, `YFR`, `PatelTejaHeyen`) with unique functional forms and/or parameter correlations. They are not designed or documented for use with PR, RK, or other cubic families.
 
 ```@docs
 Clapeyron.α_function

--- a/docs/src/properties/multi.md
+++ b/docs/src/properties/multi.md
@@ -90,29 +90,57 @@ Clapeyron.chemical_stability
 Clapeyron.tpd
 ```
 
+## Flash methods
 
-## TP Flash
+### Quick summary of available flash methods
+
+In the following table:
+
+- P,T represent pressure and temperature.
+- X,Y represent any arbitrary specification (enthalpy, volume, internal energy, etc).
+- Q represents the (molar) vapour fraction. Q = 1 is the specification of the dew point, Q = 0 corresponds to the bubble point.
+
+| Method Name | Flash Type | maximum phases | Derivative Order | Activity Models | Electrolyte Models | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| `RRTPFlash` | P-T | 2 (VLE,LLE)| First order | No (cubic EoS) | Yes | Rachford-Rice (RR) Flash |
+| `MichelsenTPFlash` | P-T | 2 (VLE,LLE) | Second order¹ | Yes  | No | RR + Gibbs optimization |
+| `MultiPhaseTPFlash` | P-T | any (automatic phase detection)  | Second order | Yes  | No  | RR + Gibbs optimization + phase search |
+| `DETPFlash` | P-T | any (via `numphases`)  | Zeroth Order | Yes  | No | Global Gibbs optimization over fixed phases |
+| `GeneralizedXYFlash` | X-Y  | 2² (VLE/LLE) | Second Order | No | No | Equilibria conditions as constrained non-linear system |
+| `RRQXFlash` | Q-T,Q-P  | 2 | First Order | Yes | No | RR update + Root-finding of Q(p)/Q(T)  |
+| `RRXYFlash` | P-Y,T-Y  | 2 (VLE/LLE) | First Order | Yes | No | RR iterations + Root-finding on Y(T)/Y(p) |
+| `MCFlashJL` | P-T | 2 (VLE) | Second order | No | No | MultiComponentFlash.jl extension |
+
+**Notes:**
+
+1. `MichelsenTPFlash` can switch how it can solve the gibbs optimization problem via the `second_order::Bool` keyword, from L-BFGS (first order method) to Newton (second order Newton)  By default, `MichelsenTPFlash` uses a first order gibbs optimization solver.
+
+1. `GeneralizedXYFlash` is a wrapper to the `xy_flash` method. While `xy_flash` can solve an arbitrary, multiphase, X-Y flash problem, `Clapeyron.jl is only capable at the moment of generating 2-phase initial points for some combinations of specifications.
+
+The default flash methods are the following:
+
+- Helmholtz models: `MichelsenTPFlash` (P-T), `GeneralizedXYFlash` (X-Y)
+- Activity Models/Composite models: `MichelsenTPFlash` (P-T), `RRQXFlash` (Q-T,Q-P), `RRXYFlash` (P-Y,T-Y)
+- Electrolyte Models: `RRTPFlash` (P-T)
+
+### Flash API
 
 ```@docs
-Clapeyron.tp_flash
-Clapeyron.DETPFlash
-Clapeyron.RRTPFlash
-Clapeyron.MichelsenTPFlash
-Clapeyron.MultiPhaseTPFlash
-Clapeyron.MCFlashJL
 Clapeyron.numphases
 Clapeyron.supports_reduction
-```
-
-## General Flash
-
-```@docs
 Clapeyron.FlashResult
 Clapeyron.FlashData
 Clapeyron.FlashSpecifications
-Clapeyron.RRQXFlash
-Clapeyron.xy_flash
-Clapeyron.GeneralizedXYFlash
+```
+
+## Flash functions
+
+!!! note
+    For legacy reasons, the return type of `tp_flash` does not return a `FlashResult`.
+    If you want to get a consistent return type for P-T flash, call `Clapeyron.tp_flash2` instead.
+
+```@docs
+Clapeyron.tp_flash
 Clapeyron.ph_flash
 Clapeyron.ps_flash
 Clapeyron.uv_flash
@@ -120,4 +148,18 @@ Clapeyron.qt_flash
 Clapeyron.qp_flash
 Clapeyron.ts_flash
 Clapeyron.vt_flash
+Clapeyron.xy_flash
+```
+
+## General methods
+
+```@docs
+Clapeyron.DETPFlash
+Clapeyron.RRTPFlash
+Clapeyron.MichelsenTPFlash
+Clapeyron.MultiPhaseTPFlash
+Clapeyron.MCFlashJL
+Clapeyron.GeneralizedXYFlash
+Clapeyron.RRQXFlash
+Clapeyron.RRXYFlash
 ```

--- a/src/methods/property_solvers/multicomponent/flash.jl
+++ b/src/methods/property_solvers/multicomponent/flash.jl
@@ -558,7 +558,7 @@ is_unknown(method::FlashMethod) = is_unknown(method.equilibrium)
 end
 
 include("flash/general_flash.jl")
-include("flash/SSXYFlash.jl")
+include("flash/RRXYFlash.jl")
 
 function xy_flash_ad(result,tup,tup_primal,spec1,spec2)
     if any(has_dual,tup)

--- a/src/methods/property_solvers/multicomponent/flash.jl
+++ b/src/methods/property_solvers/multicomponent/flash.jl
@@ -197,6 +197,11 @@ function Base.show(io::IO,mime::MIME"text/plain",obj::FlashResult)
     comps,β,volumes,data = obj
     np = length(comps)
     compact_io = IOContext(io, :compact => true)
+    if data.vapour_idx == -1
+        print(io,"LLE ")
+    elseif data.vapour_idx > 0
+        print(io,"VLE ")
+    end
     print(io,"Flash result at T = ")
     print(compact_io,data.T)
     print(io,", p = ")
@@ -569,7 +574,7 @@ function xy_flash_ad(result,tup,tup_primal,spec1,spec2)
 
         function f(input,tups)
             model0,_val1,_val2,zbulk = tups
-            TT = Base.promote_eltype(model0,_val1,_val2,zbulk,input)   
+            TT = Base.promote_eltype(model0,_val1,_val2,zbulk,input)
             output = similar(input,TT)
             spec = FlashSpecifications(spec1,_val1,spec2,_val2)
             xy_flash_neq(output,model0,zbulk,np,input,spec,nothing)
@@ -622,7 +627,7 @@ function __xy_flash_ad1_fillβ(orig::AbstractVector{T},β::B,ix) where {T,B}
 end
 
 function xy_flash_ad1(result,tup,tup_primal,spec1,spec2)
-    
+
     function f(input,tups)
         model0,_val1,_val2,zbulk = tups
         v0,T0 = input
@@ -630,7 +635,7 @@ function xy_flash_ad1(result,tup,tup_primal,spec1,spec2)
         f2 = spec_to_vt(model0,v0,T0,zbulk,spec2) - _val2
         return SVector(f1,f2)
     end
-    
+
     i = findfirst(!iszero,result.fractions)
     λT = result.data.T
     λv = result.volumes[i]*sum(result.fractions)
@@ -654,7 +659,7 @@ function xy_flash_ad1(result,tup,tup_primal,spec1,spec2)
     if result.data.g isa Number && !isnan(result.data.g)
         return FlashResult(model,∂p,∂T,∂comps,∂β,∂volumes,sort = false)
     end
-    
+
     return FlashResult(∂comps,∂β,∂volumes,FlashData(∂p,∂T))
 end
 

--- a/src/methods/property_solvers/multicomponent/flash.jl
+++ b/src/methods/property_solvers/multicomponent/flash.jl
@@ -307,6 +307,9 @@ function eval_flashresult_prop(model,state,f::F) where F
 end
 
 function eval_flashresult_prop_i(model,state,f::F,i,mass_prop) where F
+    if i == 0
+        return eval_flashresult_prop(model,state,f)
+    end
     p = pressure(state)
     T = temperature(state)
     res = zero(Base.promote_eltype(model,state))
@@ -359,6 +362,12 @@ end
 @inline identify_phase(data::FlashData,i::Integer) = vapour_idx_to_symbol(data.vapour_idx,i)
 @inline identify_phase(i0::Integer,i::Integer) = vapour_idx_to_symbol(i0,i)
 
+function identify_phase(model::EoSModel,state::FlashResult,i::Integer)
+    phase0 = identify_phase(state,i)
+    !is_unknown(phase0) && return phase0
+    return identify_phase(model,pressure(state),temperature(state),state.compositions[i],vol = state.volumes[i])
+end
+
 for prop in [:isochoric_heat_capacity, :isobaric_heat_capacity, :adiabatic_index,
     :mass_isochoric_heat_capacity, :mass_isobaric_heat_capacity,
     :isothermal_compressibility, :isentropic_compressibility, :speed_of_sound,
@@ -366,7 +375,6 @@ for prop in [:isochoric_heat_capacity, :isobaric_heat_capacity, :adiabatic_index
     #higher :derivative :order :properties
     :fundamental_derivative_of_gas_dynamics,
     #volume :properties
-    :identify_phase,
     :chemical_potential,:chemical_potential_res]
     is_mass = prop == :mass_isochoric_heat_capacity || prop == :mass_isobaric_heat_capacity
     @eval begin
@@ -550,6 +558,7 @@ is_unknown(method::FlashMethod) = is_unknown(method.equilibrium)
 end
 
 include("flash/general_flash.jl")
+include("flash/SSXYFlash.jl")
 
 function xy_flash_ad(result,tup,tup_primal,spec1,spec2)
     if any(has_dual,tup)

--- a/src/methods/property_solvers/multicomponent/flash/PH.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PH.jl
@@ -79,7 +79,7 @@ function ph_flash_impl(model,p,h,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
-function ph_flash_impl(model,p,h,z,method::SSXYFlash)
+function ph_flash_impl(model,p,h,z,method::RRXYFlash)
     modelx = __tpflash_cache_model(model,p,NaN,z,:vle)
     flash0 = px_flash_x0(modelx,p,h,z,enthalpy,method)
     isone(numphases(flash0)) && return flash0

--- a/src/methods/property_solvers/multicomponent/flash/PH.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PH.jl
@@ -79,4 +79,12 @@ function ph_flash_impl(model,p,h,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
+function ph_flash_impl(model,p,h,z,method::SSXYFlash)
+    modelx = __tpflash_cache_model(model,p,NaN,z,:vle)
+    flash0 = px_flash_x0(modelx,p,h,z,enthalpy,method)
+    isone(numphases(flash0)) && return flash0
+    spec = FlashSpecifications(pressure,p,enthalpy,h)
+    return xy_flash(modelx,spec,z,flash0,method)
+end
+
 export ph_flash

--- a/src/methods/property_solvers/multicomponent/flash/PS.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PS.jl
@@ -78,7 +78,7 @@ function ps_flash_impl(model,p,s,z,method::GeneralizedXYFlash)
 end
 
 function ps_flash_impl(model,p,s,z,method::RRXYFlash)
-    modelx = __tpflash_cache_model(modelx,p,NaN,z,:vle)
+    modelx = __tpflash_cache_model(model,p,NaN,z,:vle)
     flash0 = px_flash_x0(modelx,p,s,z,entropy,method)
     isone(numphases(flash0)) && return flash0
     spec = FlashSpecifications(pressure,p,entropy,s)

--- a/src/methods/property_solvers/multicomponent/flash/PS.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PS.jl
@@ -77,7 +77,7 @@ function ps_flash_impl(model,p,s,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
-function ps_flash_impl(model,p,s,z,method::SSXYFlash)
+function ps_flash_impl(model,p,s,z,method::RRXYFlash)
     modelx = __tpflash_cache_model(modelx,p,NaN,z,:vle)
     flash0 = px_flash_x0(modelx,p,s,z,entropy,method)
     isone(numphases(flash0)) && return flash0

--- a/src/methods/property_solvers/multicomponent/flash/PS.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PS.jl
@@ -77,4 +77,12 @@ function ps_flash_impl(model,p,s,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
+function ps_flash_impl(model,p,s,z,method::SSXYFlash)
+    modelx = __tpflash_cache_model(modelx,p,NaN,z,:vle)
+    flash0 = px_flash_x0(modelx,p,s,z,entropy,method)
+    isone(numphases(flash0)) && return flash0
+    spec = FlashSpecifications(pressure,p,entropy,s)
+    return xy_flash(modelx,spec,z,flash0,method)
+end
+
 export ps_flash

--- a/src/methods/property_solvers/multicomponent/flash/PT.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PT.jl
@@ -122,8 +122,16 @@ function tp_flash2_to_tpflash(model,p,T,z,result)
 end
 
 function tp_flash_impl(model,p,T,z,method::GeneralizedXYFlash)
-    flash0 = px_flash_x0(model,p,T,z,temperature,method)
+    flash0 = pt_flash_x0(model,p,T,z,method)
     isone(numphases(flash0)) && return flash0
     spec = FlashSpecifications(pressure,p,temperature,T)
     return xy_flash(model,spec,z,flash0,method)
+end
+
+function tp_flash_impl(model,p,T,z,method::SSXYFlash)
+    modelx = __tpflash_cache_model(model,p,T,z,:vle)
+    flash0 = pt_flash_x0(modelx,p,T,z,method)
+    isone(numphases(flash0)) && return flash0
+    spec = FlashSpecifications(pressure,p,temperature,T)
+    return xy_flash(modelx,spec,z,flash0,method)
 end

--- a/src/methods/property_solvers/multicomponent/flash/PT.jl
+++ b/src/methods/property_solvers/multicomponent/flash/PT.jl
@@ -128,7 +128,7 @@ function tp_flash_impl(model,p,T,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
-function tp_flash_impl(model,p,T,z,method::SSXYFlash)
+function tp_flash_impl(model,p,T,z,method::RRXYFlash)
     modelx = __tpflash_cache_model(model,p,T,z,:vle)
     flash0 = pt_flash_x0(modelx,p,T,z,method)
     isone(numphases(flash0)) && return flash0

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -213,19 +213,27 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     β = convert(TT,flash0.fractions[2])/sum(flash0.fractions)
     OF_old = convert(TT,NaN)
     OF = convert(TT,NaN)
+    
+    
     phasez = :unknown
     iz = 0
     volz = convert(TT,NaN)
 
+    αK = convert(TT,NaN)
+    outer_lnK_old = similar(z,TT) 
+
     ss_status = RREq #we suppose equilibria, the solver then will see if we are in eq or not.
     outer_status = :working
+
     #=
     :working
     :failure
     :trivial
     :maxiter
+    :bounded
     =#
 
+    OF_state = ((OF,OF,OF),(OF,OF,OF),TT(0.6),:iter0) #rootfinding state
 
     dlnϕ_cache = ∂lnϕ_cache(model, val1, val2, x, Val{false}())
     max_iters = method.max_iters
@@ -248,6 +256,7 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         ss_converged = false
         ss_count = 0
         total_outer_iters += 1
+        outer_lnK_old .= lnK
         for j in 1:ss_iters
             ss_status == RRTrivial && break
             ss_status == RRFailure && break
@@ -286,7 +295,7 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         ss_status == RRTrivial && break
         ss_status == RRFailure && break
         OF_old = OF
-        
+
         #calculate liquid volumes with PTFlashWrapper
         is_volume && update_volume!(model,result,p,T)
 
@@ -299,11 +308,12 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         end
         OF = spec_i - spec_obj
         OF_pT = zero(OF)
-
         if iter_type == :pt
             #do nothing
         elseif iter_type == :tx
             if i == 1
+                lnp = log(p)
+                OF_state = Solvers.solve1_update_state(OF_state,lnp,OF)
                 p_old = p
                 #starting point, we just move inside the flash
                 if is_vapour(phasey) && β > 0.5
@@ -312,16 +322,17 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
                     p -= sqrt(tol_pT)*p
                 end
             else
-
-                lnp = log(p)
-                dOF = (OF - OF_old)/(log(p/p_old)) #just secant, maybe another method could be better?
+                lnp_old = log(p_old)
                 p_old = p
-                lnp = lnp - OF/dOF
-                p = exp(lnp)
+                lnp = log(p)
+                lnp_new,OF_state = Solvers.solve1_new_iter(OF_state,lnp,OF,full_iter = ss_converged)
+                p = exp(lnp_new)
+                αK = (lnp_new - lnp_old)/(lnp - lnp_old)
             end
             OF_pT = (p - p_old)/p
-        else #px    
+        else #px
             if i == 1
+                OF_state = Solvers.solve1_update_state(OF_state,1/T,OF)
                 T_old = T
                 #starting point, we just move inside the flash
                 if is_vapour(phasey) && β > 0.5
@@ -330,22 +341,29 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
                     T += sqrt(tol_pT)*T
                 end
             else
+                τ_old = 1/T_old
                 τ = 1/T
-                dOF = (OF - OF_old)/(τ - 1/T_old) #just secant, maybe another method could be better?
                 T_old = T
-                τ = τ - OF/dOF
-                T = 1/τ
+                τ_new,OF_state = Solvers.solve1_new_iter(OF_state,τ,OF,full_iter = ss_converged)
+                T = 1/τ_new
+                αK = (τ_new - τ_old)/(τ - τ_old)
             end
             OF_pT = (T - T_old)/T
             update_temperature!(model,T)
         end
+
+        if outer_status == :bounded
+            α = clamp(αK,zero(αK),one(αK))
+            lnK .= α .* lnK .+ (1 - α) .* outer_lnK_old
+        end
+
         !isfinite(OF) && (outer_status = :failure)
         !isfinite(T) && (outer_status = :failure)
         !isfinite(p) && (outer_status = :failure)
         ss_status == RRFailure && (outer_status = :failure)
-
+        ss_converged && i > 3 && (outer_status = :bounded)
         abs(OF) < tol_of && ss_converged && break
-        max(abs(T - T_old),abs(p - p_old)) < tol_pT && iter_type != :pt && ss_converged && break
+        abs(OF_pT) < tol_pT && iter_type != :pt && ss_converged && break
         i == max_iters && (outer_status = :maxiter)
 
         if ss_status == RRTrivial && outer_status != :failure

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -361,7 +361,7 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         !isfinite(T) && (outer_status = :failure)
         !isfinite(p) && (outer_status = :failure)
         ss_status == RRFailure && (outer_status = :failure)
-        ss_converged && i > 3 && (outer_status = :bounded)
+        ss_converged && i > 3 && abs(OF_pT) < sqrt(tol_pT) && (outer_status = :bounded)
         abs(OF) < tol_of && ss_converged && break
         abs(OF_pT) < tol_pT && iter_type != :pt && ss_converged && break
         i == max_iters && (outer_status = :maxiter)

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -1,5 +1,5 @@
 """
-    SSXYFlash{T}(;kwargs...)
+    RRXYFlash{T}(;kwargs...)
 
 Method to solve non-reactive multicomponent, two-phase flash problem, using a generalized succesive substitution formulation.
 
@@ -20,7 +20,7 @@ Only two phases are supported. If `K0` is `nothing`, it will be calculated via f
 - `ss_iters` = maximum number of inner sucessive substitution iterations.
 - `flash_result::FlashResult`: can be provided instead of `x0`,`y0` and `vol0` for initial guesses.
 """
-struct SSXYFlash{P,T} <: FlashMethod
+struct RRXYFlash{P,T} <: FlashMethod
     equilibrium::Symbol
     T0::Union{P,Nothing}
     p0::Union{P,Nothing}
@@ -36,7 +36,7 @@ struct SSXYFlash{P,T} <: FlashMethod
     verbose::Bool
 end
 
-function Solvers.primalval(method::SSXYFlash{P,T}) where {P,T}
+function Solvers.primalval(method::RRXYFlash{P,T}) where {P,T}
     if P == Nothing
         λP = Nothing
     else
@@ -48,27 +48,27 @@ function Solvers.primalval(method::SSXYFlash{P,T}) where {P,T}
     else
         λT = Solvers.primal_eltype(P)
     end
-    return SSXYFlash{λP,λT}(method.equilibrium,primalval(method.T0),primalval(method.p0),
+    return RRXYFlash{λP,λT}(method.equilibrium,primalval(method.T0),primalval(method.p0),
                     primalval(method.K0),primalval(method.x0),primalval(method.y0),primalval(method.v0),
                     method.tol_xy,method.tol_pT,method.tol_of,
                     method.max_iters,method.ss_iters,method.verbose)
 end
 
-Base.eltype(method::SSXYFlash{T}) where T = T
+Base.eltype(method::RRXYFlash{T}) where T = T
 
-function index_reduction(m::SSXYFlash,idx::AbstractVector)
+function index_reduction(m::RRXYFlash,idx::AbstractVector)
     K0,x0,y0 = method.K0,method.x0,method.y0
     K0 !== nothing && (K0 = K0[idx])
     x0 !== nothing && (x0 = x0[idx])
     y0 !== nothing && (y0 = y0[idx])
-    return SSXYFlash(;equilibrium,m.T0,m.p0,K0,x0,y0,m.v0,m.tol_xy,m.tol_pT,m.tol_of,m.max_iters,m.ss_iters,m.verbose)
+    return RRXYFlash(;equilibrium,m.T0,m.p0,K0,x0,y0,m.v0,m.tol_xy,m.tol_pT,m.tol_of,m.max_iters,m.ss_iters,m.verbose)
 end
 
-index_reduction(m::SSXYFlash{Nothing,Nothing},idx::AbstractVector) = m
+index_reduction(m::RRXYFlash{Nothing,Nothing},idx::AbstractVector) = m
 
-numphases(::SSXYFlash) = 2
+numphases(::RRXYFlash) = 2
 
-function SSXYFlash(;equilibrium = :unknown,
+function RRXYFlash(;equilibrium = :unknown,
                         T0 = nothing,
                         p0 = nothing,
                         K0 = nothing,
@@ -83,16 +83,16 @@ function SSXYFlash(;equilibrium = :unknown,
                         flash_result = nothing,
                         verbose = false)
 
-    !(is_vle(equilibrium) | is_lle(equilibrium) | is_unknown(equilibrium))  && throw(error("invalid equilibrium specification for SSXYFlash"))
+    !(is_vle(equilibrium) | is_lle(equilibrium) | is_unknown(equilibrium))  && throw(error("invalid equilibrium specification for RRXYFlash"))
     if flash_result isa FlashResult
         comps,β,volumes = flash_result.compositions,flash_result.fractions,flash_result.volumes
         np = numphases(flash_result)
-        np != 2 && incorrect_np_flash_error(SSXYFlash,flash_result)
+        np != 2 && incorrect_np_flash_error(RRXYFlash,flash_result)
         w1,w2 = comps[1],comps[2]
         v = (volumes[1],volumes[2])
         P00 = flash_result.data.p
         T00 = flash_result.data.T
-        return SSXYFlash(;equilibrium = equilibrium,T0 = T00,p0 = P00,x0 = w1,y0 = w2,v0 = v,
+        return RRXYFlash(;equilibrium = equilibrium,T0 = T00,p0 = P00,x0 = w1,y0 = w2,v0 = v,
                         tol_xy = tol_xy,tol_pT = tol_pT,tol_of = tol_of,
                         max_iters = max_iters,ss_iters = ss_iters,verbose = verbose)
     end
@@ -128,7 +128,7 @@ function SSXYFlash(;equilibrium = :unknown,
     else
         S = typeof(something(T0,p0))
     end
-    return SSXYFlash{S,TT}(equilibrium,T0,p0,K0,x0,y0,_v0,
+    return RRXYFlash{S,TT}(equilibrium,T0,p0,K0,x0,y0,_v0,
                             tol_xy,tol_pT,tol_of,
                             max_iters,ss_iters,verbose)
 end
@@ -138,7 +138,7 @@ function update_volume!(model,result,p = pressure(result),T = temperature(result
     return result
 end
 
-function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResult,method::SSXYFlash)
+function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResult,method::RRXYFlash)
     #we suppose model is already cached
 
     verbose = method.verbose
@@ -445,4 +445,4 @@ verbose &&
     return flash_result
 end
 
-export SSXYFlash
+export RRXYFlash

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -153,11 +153,11 @@ function ss_xy_flash_standardize_specs(specs::FlashSpecifications{typeof(tempera
     end
 end
 
-function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T2,<:Any,Union{typeof(pressure),typeof(temperature)},<:Any}) where {T1}
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T1,<:Any,Union{typeof(pressure),typeof(temperature)},<:Any}) where {T1}
     return ss_xy_flash_standardize_specs(FlashSpecifications(specs.spec2,specs.val2,specs.spec1,specs.val1))
 end
 
-function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T2,<:Any,T2,<:Any}) where {T1,T2}
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T1,<:Any,T2,<:Any}) where {T1,T2}
     throw(ArgumentError("ss_xy_flash does not support $specs"))
 end
 

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -78,8 +78,8 @@ function RRXYFlash(;equilibrium = :unknown,
                         tol_xy = 1e-10,
                         tol_pT = 1e-12,
                         tol_of = 1e-10,
-                        max_iters = 50,
-                        ss_iters = 10,
+                        max_iters = 100,
+                        ss_iters = 5,
                         flash_result = nothing,
                         verbose = false)
 
@@ -133,9 +133,32 @@ function RRXYFlash(;equilibrium = :unknown,
                             max_iters,ss_iters,verbose)
 end
 
-
 function update_volume!(model,result,p = pressure(result),T = temperature(result))
     return result
+end
+
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{typeof(pressure),<:Any,T2,<:Any}) where T2
+    if specs.spec2 == temperature
+        return :pt,specs
+    else
+        return :px,specs
+    end
+end
+
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{typeof(temperature),<:Any,T2,<:Any}) where T2
+    if specs.spec2 == pressure
+        return :pt,FlashSpecifications(specs.spec2,specs.val2,specs.spec1,specs.val1)
+    else
+        return :tx,specs
+    end
+end
+
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T2,<:Any,T2,<:Any}) where {T1,T2::Union{typeof(pressure),typeof(temperature)}}
+    return ss_xy_flash_standardize_specs(FlashSpecifications(specs.spec2,specs.val2,specs.spec1,specs.val1))
+end
+
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T2,<:Any,T2,<:Any}) where {T1,T2}
+    throw(ArgumentError("ss_xy_flash does not support $specs"))
 end
 
 function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResult,method::RRXYFlash)
@@ -144,49 +167,20 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     verbose = method.verbose
     verbose && @info "start of SS-XY flash with $spec"
     ∑z = sum(z)
-    val1,val2 = spec.val1,spec.val2
-    spec1,spec2 = spec.spec1,spec.spec2
 
-    iter_type = if ((spec1 == temperature) & (spec2 == pressure)) || ((spec2 == temperature) & (spec1 == pressure))
-        :pt #PT-flash
-    elseif ((spec1 == temperature) & (spec2 != temperature)) || ((spec2 == temperature) & (spec1 != temperature))
-        :tx #TX-flash: p is updated
-    elseif ((spec1 == pressure) & (spec2 != pressure)) || ((spec2 == pressure) & (spec1 != pressure))
-        :px #PX-flash: T is updated
-    else
-        throw(ArgumentError("ss_xy_flash does not support $spec"))
-    end
-
-    TT = Base.promote_eltype(model,val1,val2,z,flash0)
-    spec_index = 2
-
+    TT = Base.promote_eltype(model,spec.val1,spec.val2,z,flash0)
+    nan = convert(TT,NaN)
+    iter_type,norm_spec = ss_xy_flash_standardize_specs(spec)
     if iter_type == :pt
-        if spec1 == temperature
-            p,T = convert(TT,val1),convert(TT,val2)
-        else
-            p,T = convert(TT,val2),convert(TT,val1)
-        end
-        spec_obj = zero(TT)
+        p,T = convert(TT,norm_spec.val1),convert(TT,norm_spec.val2)
     elseif iter_type == :tx
-        p = convert(TT,pressure(flash0))
-        if spec1 == temperature
-            T,spec_obj = convert(TT,val1),convert(TT,val2)
-        else
-            T,spec_obj = convert(TT,val2),convert(TT,val1)
-            spec_index = 1
-        end
-    else
-        T = convert(TT,temperature(flash0))
-        if spec1 == pressure
-            p,spec_obj = convert(TT,val1),convert(TT,val2)
-        else
-            p,spec_obj = convert(TT,val2),convert(TT,val1)
-            spec_index = 1
-        end
+        p,T = convert(TT,pressure(flash0)),convert(TT,norm_spec.val1)
+    else #px
+        p,T = convert(TT,norm_spec.val1),convert(TT,temperature(flash0))
     end
 
-    #PTFlashWrapper needs to know this to update the liquid volume
-    is_volume = spec1 == volume || spec2 == volume
+    spec_obj = norm_spec.val2
+    spec_function = norm_spec.spec2
 
     T_old = T
     p_old = p
@@ -198,55 +192,58 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     y .= flash0.compositions[2]
     volx = convert(TT,flash0.volumes[1])
     voly = convert(TT,flash0.volumes[2])
+
     phasex = identify_phase(model,flash0,1)
     phasey = identify_phase(model,flash0,2)
     non_inx = FillArrays.Fill(false,nc)
     non_inw = (non_inx,non_inx)
     phases = (phasex,phasey)
+
     lnK = similar(z,TT)
     lnK_old = similar(z,TT)
-
     K = similar(z,TT)
     K .= y ./ x
     K_old = similar(K)
+    outer_lnK_old = similar(z,TT)
 
     β = convert(TT,flash0.fractions[2])/sum(flash0.fractions)
-    OF_old = convert(TT,NaN)
-    OF = convert(TT,NaN)
-    
-    
+    OF_old = nan
+    OF = nan
+
+    #used if the phase is trivial
     phasez = :unknown
     iz = 0
-    volz = convert(TT,NaN)
+    volz = nan
 
-    αK = convert(TT,NaN)
-    outer_lnK_old = similar(z,TT) 
+    #we suppose equilibria, the solver then will see if we are in eq or not.
+    ss_status = RREq
 
-    ss_status = RREq #we suppose equilibria, the solver then will see if we are in eq or not.
-    outer_status = :working
-
+    outer_status = :initial
     #=
-    :working
-    :failure
-    :trivial
-    :maxiter
-    :bounded
+    iteration states:
+
+    :initial : initial iterations: dampened secant updates to p/T
+    :failure : NaN appeared
+    :trivial : one phase
+    :maxiter : last iteration
+    :bounded : solver has found bounds, so solution is guaranteed
     =#
 
-    OF_state = ((OF,OF,OF),(OF,OF,OF),TT(0.6),:iter0) #rootfinding state
+    #initial root-finding state
+    OF_state = Solvers.solve1_initial_state(TT)
 
-    dlnϕ_cache = ∂lnϕ_cache(model, val1, val2, x, Val{false}())
+    dlnϕ_cache = ∂lnϕ_cache(model, p, T, x, Val{false}())
     max_iters = method.max_iters
     ss_iters = method.ss_iters
     total_ss_iters = 0
     total_outer_iters = 0
+
     tol_of = convert(TT,method.tol_of)
     tol_pT = convert(TT,method.tol_pT)
     tol_xy = convert(TT,method.tol_xy)
     lle = is_liquid(phasex) && is_liquid(phasey)
     vapour_idx = lle ? -1 : 2
     flash_result = FlashResult([x,y],[β,β],[volx,voly],FlashData(p,T,zero(TT),vapour_idx))
-
 
     verbose && @info "________________________________________________________________________________________
       iter  ss_iter  status    p                T                OF_spec          pT_OF"
@@ -257,15 +254,18 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         ss_count = 0
         total_outer_iters += 1
         outer_lnK_old .= lnK
+
+        #inner Rachford-Rice iterations. adapted from MichelsenTPFlash
         for j in 1:ss_iters
             ss_status == RRTrivial && break
             ss_status == RRFailure && break
-            ss_count += 1
-            total_ss_iters += 1
+
             if error_lnK < tol_xy
                 ss_converged = true
                 break
             end
+            ss_count += 1
+            total_ss_iters += 1
 
             lnK_old .= lnK
             lnK,volx,voly,_ = update_K!(lnK,model,p,T,x,y,z,β,(volx,voly),phases,non_inw,dlnϕ_cache)
@@ -296,76 +296,63 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         ss_status == RRFailure && break
         OF_old = OF
 
-        #calculate liquid volumes with PTFlashWrapper
-        is_volume && update_volume!(model,result,p,T)
+        #calculate liquid volumes with PTFlashWrapper, if necessary
+        spec_function === volume && update_volume!(model,result,p,T)
 
-        if spec_index == 1
-            spec_i = spec1(model,flash_result,iz)
-        elseif spec_index == 2
-            spec_i = spec2(model,flash_result,iz)
+        #Objective function
+        OF = spec_function(model,flash_result,iz) - spec_obj
+        α_lnK = zero(OF)
+        w̄,w̄_old,w,w_old,w̄_new = nan,nan,nan,nan,nan
+
+        if iter_type == :tx
+            lnp,lnp_old = log(p),log(p_old)
+            w̄,w̄_old,w,w_old = lnp,lnp_old,p,p_old
+        elseif iter_type == :px
+            τ,τ_old = 1/T,1/T_old
+            w̄,w̄_old,w,w_old = τ,τ_old,T,T_old
+        end
+        p_old,T_old = p,T
+
+        if i == 1
+            #direction to move in first iter. move towards middle of vapour fraction, if possible.
+            #by default, it is defined in pressure terms (high pressure -> less vapour)
+            #we invert it if the temperature is the variable being iterated.
+            _sign = (is_vapour(phasey) && β > 0.5) ? 1 : -1
+            iter_type == :tx && (_sign *= -1)
+            OF_state = Solvers.solve1_update_state(OF_state,w̄,OF)
+            w_new = w + sqrt(tol_pT)*_sign*w
+            w̄_new = w_new #not used here
         else
-            spec_i = zero(OF)
+            w̄_new,OF_state = Solvers.solve1_new_iter(OF_state,w̄,OF,full_iter = ss_converged)
+            α_lnK = (w̄_new - w̄_old)/(w̄ - w̄_old)
         end
-        OF = spec_i - spec_obj
-        OF_pT = zero(OF)
-        if iter_type == :pt
-            #do nothing
-        elseif iter_type == :tx
-            if i == 1
-                lnp = log(p)
-                OF_state = Solvers.solve1_update_state(OF_state,lnp,OF)
-                p_old = p
-                #starting point, we just move inside the flash
-                if is_vapour(phasey) && β > 0.5
-                    p += sqrt(tol_pT)*p
-                else
-                    p -= sqrt(tol_pT)*p
-                end
-            else
-                lnp_old = log(p_old)
-                p_old = p
-                lnp = log(p)
-                lnp_new,OF_state = Solvers.solve1_new_iter(OF_state,lnp,OF,full_iter = ss_converged)
-                p = exp(lnp_new)
-                αK = (lnp_new - lnp_old)/(lnp - lnp_old)
-            end
-            OF_pT = (p - p_old)/p
-        else #px
-            if i == 1
-                OF_state = Solvers.solve1_update_state(OF_state,1/T,OF)
-                T_old = T
-                #starting point, we just move inside the flash
-                if is_vapour(phasey) && β > 0.5
-                    T -= sqrt(tol_pT)*T
-                else
-                    T += sqrt(tol_pT)*T
-                end
-            else
-                τ_old = 1/T_old
-                τ = 1/T
-                T_old = T
-                τ_new,OF_state = Solvers.solve1_new_iter(OF_state,τ,OF,full_iter = ss_converged)
-                T = 1/τ_new
-                αK = (τ_new - τ_old)/(τ - τ_old)
-            end
-            OF_pT = (T - T_old)/T
+
+        if iter_type == :px
+            w_old = T
+            T = w = i == 1 ? w̄_new : 1/w̄_new
             update_temperature!(model,T)
+        elseif iter_type == :tx
+            w_old = p
+            p = w = i == 1 ? w̄_new : exp(w̄_new)
         end
 
+        OF_pT = (w - w_old)/w
+
+        #linear interpolation to suggest new K.
         if outer_status == :bounded
-            α = clamp(αK,zero(αK),one(αK))
-            lnK .= α .* lnK .+ (1 - α) .* outer_lnK_old
+            lnK .= α_lnK .* lnK .+ (1 - α_lnK) .* outer_lnK_old
         end
 
-        !isfinite(OF) && (outer_status = :failure)
-        !isfinite(T) && (outer_status = :failure)
-        !isfinite(p) && (outer_status = :failure)
-        ss_status == RRFailure && (outer_status = :failure)
-        ss_converged && i > 3 && abs(OF_pT) < sqrt(tol_pT) && (outer_status = :bounded)
+        #outer iteration status determination
+        !isfinite(OF) && (outer_status = :failure) #failure in objective
+        !isfinite(w) && (outer_status = :failure) #failure in p/T
+        ss_status == RRFailure && (outer_status = :failure) #failure in SS iteration
+        ss_converged && i > 3  && abs(OF_pT) < sqrt(tol_pT) && (outer_status = :bounded)
         abs(OF) < tol_of && ss_converged && break
         abs(OF_pT) < tol_pT && iter_type != :pt && ss_converged && break
         i == max_iters && (outer_status = :maxiter)
 
+        #if the iteration results in a trivial phase, keep going until the specifications are satisfied.
         if ss_status == RRTrivial && outer_status != :failure
             if is_unknown(phasez) && outer_status != :trivial
                 phasez = identify_phase(model,p,T,z)
@@ -425,10 +412,10 @@ verbose &&
     verbose && ss_status == RRVapour && @info "procedure converged to a single vapour phase."
 
     if outer_status == :failure
-        flash_result.compositions[1] .= NaN
-        flash_result.compositions[2] .= NaN
-        flash_result.volumes .= NaN
-        flash_result.fractions .= NaN
+        flash_result.compositions[1] .= nan
+        flash_result.compositions[2] .= nan
+        flash_result.volumes .= nan
+        flash_result.fractions .= nan
     end
 
     if ss_status != RREq && outer_status != :trivial #trivial system detected after the iterations
@@ -443,8 +430,8 @@ verbose &&
             β = one(TT)
             vz = volume(model,p,T,z,phase = :v)/∑z
         else
-            β = convert(TT,NaN)
-            vz = convert(TT,NaN)
+            β = nan
+            vz = nan
         end
         flash_result.volumes[1] = vz
         flash_result.volumes[2] = vz
@@ -455,7 +442,7 @@ verbose &&
     if outer_status != :failure
         g,_ = modified_gibbs(model,flash_result)
     else
-        g = convert(TT,NaN)
+        g = nan
     end
 
     flash_result = FlashResult(flash_result.compositions,flash_result.fractions,flash_result.volumes,FlashData(p,T,g,vapour_idx))

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -153,7 +153,7 @@ function ss_xy_flash_standardize_specs(specs::FlashSpecifications{typeof(tempera
     end
 end
 
-function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T2,<:Any,T2,<:Any}) where {T1,T2::Union{typeof(pressure),typeof(temperature)}}
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T2,<:Any,Union{typeof(pressure),typeof(temperature)},<:Any}) where {T1}
     return ss_xy_flash_standardize_specs(FlashSpecifications(specs.spec2,specs.val2,specs.spec1,specs.val1))
 end
 

--- a/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/RRXYFlash.jl
@@ -153,12 +153,8 @@ function ss_xy_flash_standardize_specs(specs::FlashSpecifications{typeof(tempera
     end
 end
 
-function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T1,<:Any,Union{typeof(pressure),typeof(temperature)},<:Any}) where {T1}
+function ss_xy_flash_standardize_specs(specs::FlashSpecifications)
     return ss_xy_flash_standardize_specs(FlashSpecifications(specs.spec2,specs.val2,specs.spec1,specs.val1))
-end
-
-function ss_xy_flash_standardize_specs(specs::FlashSpecifications{T1,<:Any,T2,<:Any}) where {T1,T2}
-    throw(ArgumentError("ss_xy_flash does not support $specs"))
 end
 
 function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResult,method::RRXYFlash)

--- a/src/methods/property_solvers/multicomponent/flash/SSXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/SSXYFlash.jl
@@ -217,7 +217,7 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     iz = 0
     volz = convert(TT,NaN)
 
-    ss_status = RREq #we suppose equilibria here
+    ss_status = RREq #we suppose equilibria, the solver then will see if we are in eq or not.
     outer_status = :working
     #=
     :working
@@ -225,6 +225,8 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     :trivial
     :maxiter
     =#
+
+
     dlnϕ_cache = ∂lnϕ_cache(model, val1, val2, x, Val{false}())
     max_iters = method.max_iters
     ss_iters = method.ss_iters
@@ -310,10 +312,14 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
                     p -= sqrt(tol_pT)*p
                 end
             else
-                dOF = (OF - OF_old)/(p - p_old) #just secant, maybe another method could be better?
-                p = p - OF/dOF
+
+                lnp = log(p)
+                dOF = (OF - OF_old)/(log(p/p_old)) #just secant, maybe another method could be better?
+                p_old = p
+                lnp = lnp - OF/dOF
+                p = exp(lnp)
             end
-            OF_pT = p - p_old
+            OF_pT = (p - p_old)/p
         else #px    
             if i == 1
                 T_old = T
@@ -324,11 +330,13 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
                     T += sqrt(tol_pT)*T
                 end
             else
-                dOF = (OF - OF_old)/(T - T_old) #just secant, maybe another method could be better?
+                τ = 1/T
+                dOF = (OF - OF_old)/(τ - 1/T_old) #just secant, maybe another method could be better?
                 T_old = T
-                T = T - OF/dOF
+                τ = τ - OF/dOF
+                T = 1/τ
             end
-            OF_pT = T - T_old
+            OF_pT = (T - T_old)/T
             update_temperature!(model,T)
         end
         !isfinite(OF) && (outer_status = :failure)

--- a/src/methods/property_solvers/multicomponent/flash/SSXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/SSXYFlash.jl
@@ -228,6 +228,8 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     dlnϕ_cache = ∂lnϕ_cache(model, val1, val2, x, Val{false}())
     max_iters = method.max_iters
     ss_iters = method.ss_iters
+    total_ss_iters = 0
+    total_outer_iters = 0
     tol_of = convert(TT,method.tol_of)
     tol_pT = convert(TT,method.tol_pT)
     tol_xy = convert(TT,method.tol_xy)
@@ -235,16 +237,20 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
     vapour_idx = lle ? -1 : 2
     flash_result = FlashResult([x,y],[β,β],[volx,voly],FlashData(p,T,zero(TT),vapour_idx))
 
-    verbose && @info "iter  ss_iter  status    p                T                OF_spec          pT_OF"
+
+    verbose && @info "________________________________________________________________________________________
+      iter  ss_iter  status    p                T                OF_spec          pT_OF"
     for i in 1:max_iters
         error_lnK = convert(TT,Inf)
         outer_status == :failure && break
         ss_converged = false
         ss_count = 0
+        total_outer_iters += 1
         for j in 1:ss_iters
             ss_status == RRTrivial && break
             ss_status == RRFailure && break
             ss_count += 1
+            total_ss_iters += 1
             if error_lnK < tol_xy
                 ss_converged = true
                 break
@@ -256,8 +262,6 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
             K .= exp.(lnK)
 
             ss_status = rachfordrice_status(K,z; K_tol = tol_xy)
-
-            #verbose && @info "$it    $status   $β  $(round(error_lnK,sigdigits=4)) $K"
 
             if isnan(β) && ss_status != RRTrivial
                 #try to save K? basically damping
@@ -339,10 +343,8 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
         if ss_status == RRTrivial && outer_status != :failure
             if is_unknown(phasez) && outer_status != :trivial
                 phasez = identify_phase(model,p,T,z)
-                x .= z
-                y .= z
-                x ./= ∑z
-                y ./= ∑z
+                x .= z ./ ∑z
+                y .= z ./ ∑z
                 vapour_idx = 2
                 if is_liquid(phasez)
                     flash_result.fractions[1] = 0
@@ -364,14 +366,70 @@ function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResul
 
         flash_result = FlashResult(flash_result.compositions,flash_result.fractions,flash_result.volumes,FlashData(p,T,zero(TT),vapour_idx))
     end
+
+verbose &&
+@info "________________________________________________________________________________________
+      Final K values:        $K
+      Final vapour fraction: $β
+      Outer iterations:      $total_outer_iters
+      SS iterations:         $total_ss_iters
+      Final temperature:     $T
+      Final pressure:        $p
+
+"
+
+    ss_status = rachfordrice_status(K,z,K_tol = tol_xy)
+    verbose && ss_status != RREq && @info "result is single-phase (does not satisfy Rachford-Rice constraints)."
+    volx,voly = flash_result.volumes[1],flash_result.volumes[2]
+    #maybe azeotrope, do nothing in this case
+    if abs(volx - voly) > sqrt(max(abs(volx),abs(voly))) && ss_status != RREq
+        verbose && @info "trivial result but different volumes (maybe azeotrope?)"
+        ss_status = RREq
+    elseif ss_status == RREq && β <= eps(eltype(β))
+        ss_status = RRLiquid
+    elseif ss_status == RREq && β >= one(β) - eps(eltype(β))
+        ss_status = RRVapour
+    elseif !material_balance_rr_converged((x,y),z,β) #material balance failed
+        verbose && @info "material balance failed."
+        ss_status = RRFailure
+        outer_status = :failure
+    end
+
+    verbose && ss_status == RRLiquid && @info "procedure converged to a single liquid phase."
+    verbose && ss_status == RRVapour && @info "procedure converged to a single vapour phase."
+
     if outer_status == :failure
         flash_result.compositions[1] .= NaN
         flash_result.compositions[2] .= NaN
         flash_result.volumes .= NaN
         flash_result.fractions .= NaN
-        g = convert(TT,NaN)
-    else
+    end
+
+    if ss_status != RREq && outer_status != :trivial #trivial system detected after the iterations
+        _0 = zero(eltype(x))
+        _1 = one(eltype(x))
+        x .= z ./ ∑z
+        y .= z ./ ∑z
+        if ss_status == RRLiquid
+            β = zero(TT)
+            vz = volume(model,p,T,z,phase = :l)/∑z
+        elseif ss_status == RRVapour
+            β = one(TT)
+            vz = volume(model,p,T,z,phase = :v)/∑z
+        else
+            β = convert(TT,NaN)
+            vz = convert(TT,NaN)
+        end
+        flash_result.volumes[1] = vz
+        flash_result.volumes[2] = vz
+        flash_result.fractions[1] = ∑z*(1-β)
+        flash_result.fractions[2] = ∑z*β
+    end
+
+    if outer_status != :failure
         g,_ = modified_gibbs(model,flash_result)
+    else
+        g = convert(TT,NaN)
     end
 
     flash_result = FlashResult(flash_result.compositions,flash_result.fractions,flash_result.volumes,FlashData(p,T,g,vapour_idx))

--- a/src/methods/property_solvers/multicomponent/flash/SSXYFlash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/SSXYFlash.jl
@@ -1,0 +1,382 @@
+"""
+    SSXYFlash{T}(;kwargs...)
+
+Method to solve non-reactive multicomponent, two-phase flash problem, using a generalized succesive substitution formulation.
+
+Only two phases are supported. If `K0` is `nothing`, it will be calculated via fugacity coefficients at p,T conditions.
+
+### Keyword Arguments:
+- `equilibrium` (optional) = equilibrium type ":vle" for liquid vapor equilibria, ":lle" for liquid liquid equilibria, `:unknown` if not specified.
+- `p0` (optional), initial guess pressure, ignored if pressure is one of the flash specifications.
+- `T0` (optional), initial guess temperature, ignored if temperature is one of the flash specifications.
+- `K0` (optional), initial guess for the K-values.
+- `x0` (optional), initial guess for the composition of phase x.
+- `y0` = optional, initial guess for the composition of phase y.
+- `vol0` = optional, initial guesses for phase x and phase y volumes.
+- `tol_xy` = absolute composition tolerance
+- `tol_pT` = relative temperature or pressure tolerance.
+- `tol_of` = absolute objective property tolerance.
+- `max_iters` = maximum number of iterations.
+- `ss_iters` = maximum number of inner sucessive substitution iterations.
+- `flash_result::FlashResult`: can be provided instead of `x0`,`y0` and `vol0` for initial guesses.
+"""
+struct SSXYFlash{P,T} <: FlashMethod
+    equilibrium::Symbol
+    T0::Union{P,Nothing}
+    p0::Union{P,Nothing}
+    K0::Union{Vector{T},Nothing}
+    x0::Union{Vector{T},Nothing}
+    y0::Union{Vector{T},Nothing}
+    v0::Union{Tuple{T,T},Nothing}
+    tol_xy::Float64
+    tol_pT::Float64
+    tol_of::Float64
+    max_iters::Int
+    ss_iters::Int
+    verbose::Bool
+end
+
+function Solvers.primalval(method::SSXYFlash{P,T}) where {P,T}
+    if P == Nothing
+        λP = Nothing
+    else
+        λP = Solvers.primal_eltype(P)
+    end
+
+    if T == Nothing
+        λT = Nothing
+    else
+        λT = Solvers.primal_eltype(P)
+    end
+    return SSXYFlash{λP,λT}(method.equilibrium,primalval(method.T0),primalval(method.p0),
+                    primalval(method.K0),primalval(method.x0),primalval(method.y0),primalval(method.v0),
+                    method.tol_xy,method.tol_pT,method.tol_of,
+                    method.max_iters,method.ss_iters,method.verbose)
+end
+
+Base.eltype(method::SSXYFlash{T}) where T = T
+
+function index_reduction(m::SSXYFlash,idx::AbstractVector)
+    K0,x0,y0 = method.K0,method.x0,method.y0
+    K0 !== nothing && (K0 = K0[idx])
+    x0 !== nothing && (x0 = x0[idx])
+    y0 !== nothing && (y0 = y0[idx])
+    return SSXYFlash(;equilibrium,m.T0,m.p0,K0,x0,y0,m.v0,m.tol_xy,m.tol_pT,m.tol_of,m.max_iters,m.ss_iters,m.verbose)
+end
+
+index_reduction(m::SSXYFlash{Nothing,Nothing},idx::AbstractVector) = m
+
+numphases(::SSXYFlash) = 2
+
+function SSXYFlash(;equilibrium = :unknown,
+                        T0 = nothing,
+                        p0 = nothing,
+                        K0 = nothing,
+                        x0 = nothing,
+                        y0 = nothing,
+                        v0 = nothing,
+                        tol_xy = 1e-10,
+                        tol_pT = 1e-12,
+                        tol_of = 1e-10,
+                        max_iters = 50,
+                        ss_iters = 10,
+                        flash_result = nothing,
+                        verbose = false)
+
+    !(is_vle(equilibrium) | is_lle(equilibrium) | is_unknown(equilibrium))  && throw(error("invalid equilibrium specification for SSXYFlash"))
+    if flash_result isa FlashResult
+        comps,β,volumes = flash_result.compositions,flash_result.fractions,flash_result.volumes
+        np = numphases(flash_result)
+        np != 2 && incorrect_np_flash_error(SSXYFlash,flash_result)
+        w1,w2 = comps[1],comps[2]
+        v = (volumes[1],volumes[2])
+        P00 = flash_result.data.p
+        T00 = flash_result.data.T
+        return SSXYFlash(;equilibrium = equilibrium,T0 = T00,p0 = P00,x0 = w1,y0 = w2,v0 = v,
+                        tol_xy = tol_xy,tol_pT = tol_pT,tol_of = tol_of,
+                        max_iters = max_iters,ss_iters = ss_iters,verbose = verbose)
+    end
+
+    if K0 == x0 == y0 === nothing #nothing specified
+        #is_lle(equilibrium)
+        T = Nothing
+    else
+        if !isnothing(K0) & isnothing(x0) & isnothing(y0) #K0 specified
+            T = eltype(K0)
+        elseif isnothing(K0) & !isnothing(x0) & !isnothing(y0)  #x0, y0 specified
+            T = eltype(x0)
+        else
+            throw(error("invalid specification of initial points"))
+        end
+    end
+
+    if T == Nothing && v0 !== nothing
+        TT = Base.promote_eltype(v0[1],v0[2])
+        _v0 = (v0[1],v0[2])
+    elseif T != nothing && v0 !== nothing
+        TT = Base.promote_eltype(one(T),v0[1],v0[2])
+        _v0 = (v0[1],v0[2])
+    else
+        TT = T
+        _v0 = v0
+    end
+
+    if T0 === nothing && p0 === nothing
+        S = Nothing
+    elseif T0 !== nothing && p0 !== nothing
+        S = typeof(T0*p0)
+    else
+        S = typeof(something(T0,p0))
+    end
+    return SSXYFlash{S,TT}(equilibrium,T0,p0,K0,x0,y0,_v0,
+                            tol_xy,tol_pT,tol_of,
+                            max_iters,ss_iters,verbose)
+end
+
+
+function update_volume!(model,result,p = pressure(result),T = temperature(result))
+    return result
+end
+
+function xy_flash(model::EoSModel,spec::FlashSpecifications,z,flash0::FlashResult,method::SSXYFlash)
+    #we suppose model is already cached
+
+    verbose = method.verbose
+    verbose && @info "start of SS-XY flash with $spec"
+    ∑z = sum(z)
+    val1,val2 = spec.val1,spec.val2
+    spec1,spec2 = spec.spec1,spec.spec2
+
+    iter_type = if ((spec1 == temperature) & (spec2 == pressure)) || ((spec2 == temperature) & (spec1 == pressure))
+        :pt #PT-flash
+    elseif ((spec1 == temperature) & (spec2 != temperature)) || ((spec2 == temperature) & (spec1 != temperature))
+        :tx #TX-flash: p is updated
+    elseif ((spec1 == pressure) & (spec2 != pressure)) || ((spec2 == pressure) & (spec1 != pressure))
+        :px #PX-flash: T is updated
+    else
+        throw(ArgumentError("ss_xy_flash does not support $spec"))
+    end
+
+    TT = Base.promote_eltype(model,val1,val2,z,flash0)
+    spec_index = 2
+
+    if iter_type == :pt
+        if spec1 == temperature
+            p,T = convert(TT,val1),convert(TT,val2)
+        else
+            p,T = convert(TT,val2),convert(TT,val1)
+        end
+        spec_obj = zero(TT)
+    elseif iter_type == :tx
+        p = convert(TT,pressure(flash0))
+        if spec1 == temperature
+            T,spec_obj = convert(TT,val1),convert(TT,val2)
+        else
+            T,spec_obj = convert(TT,val2),convert(TT,val1)
+            spec_index = 1
+        end
+    else
+        T = convert(TT,temperature(flash0))
+        if spec1 == pressure
+            p,spec_obj = convert(TT,val1),convert(TT,val2)
+        else
+            p,spec_obj = convert(TT,val2),convert(TT,val1)
+            spec_index = 1
+        end
+    end
+
+    #PTFlashWrapper needs to know this to update the liquid volume
+    is_volume = spec1 == volume || spec2 == volume
+
+    T_old = T
+    p_old = p
+
+    x = similar(z,TT)
+    y = similar(z,TT)
+    nc = length(model)
+    x .= flash0.compositions[1]
+    y .= flash0.compositions[2]
+    volx = convert(TT,flash0.volumes[1])
+    voly = convert(TT,flash0.volumes[2])
+    phasex = identify_phase(model,flash0,1)
+    phasey = identify_phase(model,flash0,2)
+    non_inx = FillArrays.Fill(false,nc)
+    non_inw = (non_inx,non_inx)
+    phases = (phasex,phasey)
+    lnK = similar(z,TT)
+    lnK_old = similar(z,TT)
+
+    K = similar(z,TT)
+    K .= y ./ x
+    K_old = similar(K)
+
+    β = convert(TT,flash0.fractions[2])/sum(flash0.fractions)
+    OF_old = convert(TT,NaN)
+    OF = convert(TT,NaN)
+    phasez = :unknown
+    iz = 0
+    volz = convert(TT,NaN)
+
+    ss_status = RREq #we suppose equilibria here
+    outer_status = :working
+    #=
+    :working
+    :failure
+    :trivial
+    :maxiter
+    =#
+    dlnϕ_cache = ∂lnϕ_cache(model, val1, val2, x, Val{false}())
+    max_iters = method.max_iters
+    ss_iters = method.ss_iters
+    tol_of = convert(TT,method.tol_of)
+    tol_pT = convert(TT,method.tol_pT)
+    tol_xy = convert(TT,method.tol_xy)
+    lle = is_liquid(phasex) && is_liquid(phasey)
+    vapour_idx = lle ? -1 : 2
+    flash_result = FlashResult([x,y],[β,β],[volx,voly],FlashData(p,T,zero(TT),vapour_idx))
+
+    verbose && @info "iter  ss_iter  status    p                T                OF_spec          pT_OF"
+    for i in 1:max_iters
+        error_lnK = convert(TT,Inf)
+        outer_status == :failure && break
+        ss_converged = false
+        ss_count = 0
+        for j in 1:ss_iters
+            ss_status == RRTrivial && break
+            ss_status == RRFailure && break
+            ss_count += 1
+            if error_lnK < tol_xy
+                ss_converged = true
+                break
+            end
+
+            lnK_old .= lnK
+            lnK,volx,voly,_ = update_K!(lnK,model,p,T,x,y,z,β,(volx,voly),phases,non_inw,dlnϕ_cache)
+            K_old .= K
+            K .= exp.(lnK)
+
+            ss_status = rachfordrice_status(K,z; K_tol = tol_xy)
+
+            #verbose && @info "$it    $status   $β  $(round(error_lnK,sigdigits=4)) $K"
+
+            if isnan(β) && ss_status != RRTrivial
+                #try to save K? basically damping
+                lnK .= 0.5 * lnK .+ 0.5 * lnK_old
+                K .= exp.(lnK)
+            end
+
+            β_old = β
+            β = rachfordrice(K, z; β0 = β, K_tol = tol_xy, verbose)
+            x,y = update_rr!(K,β,z,x,y)
+
+            error_lnK = dnorm(lnK,lnK_old,1)
+        end
+
+        flash_result.volumes[1] = volx
+        flash_result.volumes[2] = voly
+        flash_result.fractions[1] = ∑z*(1 - β)
+        flash_result.fractions[2] = ∑z*β
+
+        ss_status == RRTrivial && break
+        ss_status == RRFailure && break
+        OF_old = OF
+        
+        #calculate liquid volumes with PTFlashWrapper
+        is_volume && update_volume!(model,result,p,T)
+
+        if spec_index == 1
+            spec_i = spec1(model,flash_result,iz)
+        elseif spec_index == 2
+            spec_i = spec2(model,flash_result,iz)
+        else
+            spec_i = zero(OF)
+        end
+        OF = spec_i - spec_obj
+        OF_pT = zero(OF)
+
+        if iter_type == :pt
+            #do nothing
+        elseif iter_type == :tx
+            if i == 1
+                p_old = p
+                #starting point, we just move inside the flash
+                if is_vapour(phasey) && β > 0.5
+                    p += sqrt(tol_pT)*p
+                else
+                    p -= sqrt(tol_pT)*p
+                end
+            else
+                dOF = (OF - OF_old)/(p - p_old) #just secant, maybe another method could be better?
+                p = p - OF/dOF
+            end
+            OF_pT = p - p_old
+        else #px    
+            if i == 1
+                T_old = T
+                #starting point, we just move inside the flash
+                if is_vapour(phasey) && β > 0.5
+                    T -= sqrt(tol_pT)*T
+                else
+                    T += sqrt(tol_pT)*T
+                end
+            else
+                dOF = (OF - OF_old)/(T - T_old) #just secant, maybe another method could be better?
+                T_old = T
+                T = T - OF/dOF
+            end
+            OF_pT = T - T_old
+            update_temperature!(model,T)
+        end
+        !isfinite(OF) && (outer_status = :failure)
+        !isfinite(T) && (outer_status = :failure)
+        !isfinite(p) && (outer_status = :failure)
+        ss_status == RRFailure && (outer_status = :failure)
+
+        abs(OF) < tol_of && ss_converged && break
+        max(abs(T - T_old),abs(p - p_old)) < tol_pT && iter_type != :pt && ss_converged && break
+        i == max_iters && (outer_status = :maxiter)
+
+        if ss_status == RRTrivial && outer_status != :failure
+            if is_unknown(phasez) && outer_status != :trivial
+                phasez = identify_phase(model,p,T,z)
+                x .= z
+                y .= z
+                x ./= ∑z
+                y ./= ∑z
+                vapour_idx = 2
+                if is_liquid(phasez)
+                    flash_result.fractions[1] = 0
+                    flash_result.fractions[2] = ∑z
+                else
+                    flash_result.fractions[1] = ∑z
+                    flash_result.fractions[2] = 0
+                end
+                outer_status = :trivial
+            end
+            volz = volume(model,p,T,z,phase = phasez,vol0 = volz)/∑z
+            flash_result.volumes .= volz
+        end
+
+        if verbose
+            bb = flash_result.fractions[2]/sum(flash_result.fractions)
+            @info "$(__pad_val(i,4))  $(__pad_val(ss_count,4))     $outer_status   $(__pad_val(p,16)) $(__pad_val(T,16)) $(__pad_val(OF,16)) $(__pad_val(OF_pT,16))"
+        end
+
+        flash_result = FlashResult(flash_result.compositions,flash_result.fractions,flash_result.volumes,FlashData(p,T,zero(TT),vapour_idx))
+    end
+    if outer_status == :failure
+        flash_result.compositions[1] .= NaN
+        flash_result.compositions[2] .= NaN
+        flash_result.volumes .= NaN
+        flash_result.fractions .= NaN
+        g = convert(TT,NaN)
+    else
+        g,_ = modified_gibbs(model,flash_result)
+    end
+
+    flash_result = FlashResult(flash_result.compositions,flash_result.fractions,flash_result.volumes,FlashData(p,T,g,vapour_idx))
+    update_volume!(model,flash_result)
+    return flash_result
+end
+
+export SSXYFlash

--- a/src/methods/property_solvers/multicomponent/flash/TS.jl
+++ b/src/methods/property_solvers/multicomponent/flash/TS.jl
@@ -66,4 +66,12 @@ function ts_flash_impl(model,T,S,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
+function ts_flash_impl(model,T,S,z,method::SSXYFlash)
+    modelx = __tpflash_cache_model(model,NaN,T,z,:vle)
+    flash0 = tx_flash_x0(modelx,T,S,z,entropy,method)
+    isone(numphases(flash0)) && return flash0
+    spec = FlashSpecifications(entropy,S,temperature,T)
+    return xy_flash(modelx,spec,z,flash0,method)
+end
+
 export ts_flash

--- a/src/methods/property_solvers/multicomponent/flash/TS.jl
+++ b/src/methods/property_solvers/multicomponent/flash/TS.jl
@@ -66,7 +66,7 @@ function ts_flash_impl(model,T,S,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
-function ts_flash_impl(model,T,S,z,method::SSXYFlash)
+function ts_flash_impl(model,T,S,z,method::RRXYFlash)
     modelx = __tpflash_cache_model(model,NaN,T,z,:vle)
     flash0 = tx_flash_x0(modelx,T,S,z,entropy,method)
     isone(numphases(flash0)) && return flash0

--- a/src/methods/property_solvers/multicomponent/flash/VT.jl
+++ b/src/methods/property_solvers/multicomponent/flash/VT.jl
@@ -66,7 +66,7 @@ function vt_flash_impl(model,V,T,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
-function vt_flash_impl(model,V,T,z,method::SSXYFlash)
+function vt_flash_impl(model,V,T,z,method::RRXYFlash)
     modelx = __tpflash_cache_model(model,NaN,T,z,:vle)
     flash0 = tx_flash_x0(modelx,T,V,z,volume,method)
     isone(numphases(flash0)) && return flash0

--- a/src/methods/property_solvers/multicomponent/flash/VT.jl
+++ b/src/methods/property_solvers/multicomponent/flash/VT.jl
@@ -66,4 +66,12 @@ function vt_flash_impl(model,V,T,z,method::GeneralizedXYFlash)
     return xy_flash(model,spec,z,flash0,method)
 end
 
+function vt_flash_impl(model,V,T,z,method::SSXYFlash)
+    modelx = __tpflash_cache_model(model,NaN,T,z,:vle)
+    flash0 = tx_flash_x0(modelx,T,V,z,volume,method)
+    isone(numphases(flash0)) && return flash0
+    spec = FlashSpecifications(volume,V,temperature,T)
+    return xy_flash(modelx,spec,z,flash0,method)
+end
+
 export vt_flash

--- a/src/methods/property_solvers/multicomponent/flash/general_flash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/general_flash.jl
@@ -851,8 +851,12 @@ function px_flash_x0(model,p,x,z,spec::F,method) where F
 
     verbose && @info "p = $p, T = $T, equilibrium status = :$_phase"
 
-    TT = Base.promote_eltype(model,p,x,z,T)
-    if _phase != :eq
+    γmodel = __γ_unwrap(model)
+    if is_lle(method) && γmodel isa ActivityModel && !(γmodel isa IdealLiquidSolution)
+        verbose && @info "using PT-flash LLE initial point"
+        lle_method = init_preferred_method(tp_flash,model,(; equilibrium = :lle))
+        return tp_flash2(model,p,T,z,lle_method)
+    elseif _phase != :eq
         verbose && @info "using pure phase initial point"
         return FlashResult(model,p,T,z,phase = _phase)
     end

--- a/src/methods/property_solvers/multicomponent/flash/general_flash.jl
+++ b/src/methods/property_solvers/multicomponent/flash/general_flash.jl
@@ -850,13 +850,11 @@ function px_flash_x0(model,p,x,z,spec::F,method) where F
     end
 
     verbose && @info "p = $p, T = $T, equilibrium status = :$_phase"
+    if is_lle(method) && is_liquid(_phase) #Tproperty converged to a liquid phase, but we can split it via tpd
+        _phase = :eq
+    end
 
-    γmodel = __γ_unwrap(model)
-    if is_lle(method) && γmodel isa ActivityModel && !(γmodel isa IdealLiquidSolution)
-        verbose && @info "using PT-flash LLE initial point"
-        lle_method = init_preferred_method(tp_flash,model,(; equilibrium = :lle))
-        return tp_flash2(model,p,T,z,lle_method)
-    elseif _phase != :eq
+    if _phase != :eq
         verbose && @info "using pure phase initial point"
         return FlashResult(model,p,T,z,phase = _phase)
     end

--- a/src/methods/property_solvers/multicomponent/tp_flash/Michelsentp_flash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/Michelsentp_flash.jl
@@ -315,7 +315,8 @@ function tp_flash_michelsen(model::EoSModel, p, T, z, method = MichelsenTPFlash(
     gibbs = one(_1)
     gibbs_dem = one(_1)
     vcache = Ref((_1, _1))
-    verbose && @info "iter  status     β                error_lnK        K"
+    verbose && @info "_____________________________________________________________________________________
+      iter  status     β                error_lnK        K"
     while !exit_early && (error_lnK > K_tol || abs(β_old-β) > 1e-9) && it < itss && status in (RREq,RRLiquid,RRVapour)
         it += 1
         itacc += 1
@@ -406,9 +407,12 @@ function tp_flash_michelsen(model::EoSModel, p, T, z, method = MichelsenTPFlash(
         K .= y ./ x
         β = rachfordrice(K, z; non_inx, non_iny, K_tol, verbose)
     end
+verbose &&
+@info "_____________________________________________________________________________________
+      Final K values:        $K
+      Final vapour fraction: $β
 
-    verbose && @info "final K values: $K"
-    verbose && @info "final vapour fraction: $β"
+"
 
     #convergence checks (TODO, seems to fail with activity models)
     status = rachfordrice_status(K,z,non_inx,non_iny,K_tol = K_tol)

--- a/src/methods/property_solvers/multicomponent/tp_flash/RRQXFlash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/RRQXFlash.jl
@@ -2,7 +2,7 @@
 update_pressure!(model,p) = nothing
 update_temperature!(model,T) = nothing
 
-function update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache)
+function update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache,verbose_cache)
     x,y,z =  w
     K,lnK = vec_cache
     #using cache
@@ -14,6 +14,7 @@ function update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache)
     lnϕx, volx = modified_lnϕ(model, p, T, x, dlnϕ_cache; phase = phasex)
     lnK .= lnϕx
     lnϕy, voly = modified_lnϕ(model, p, T, y, dlnϕ_cache; phase = phasey)
+
     lnK .-= lnϕy
     K .= exp.(lnK)
     lnK[1] = volx
@@ -23,20 +24,34 @@ function update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache)
         non_iny[i] && (K[i] = 0)
     end
     x,y = update_rr!(K,β,z,x,y,non_inx,non_iny,false)
-    return sum(x) - sum(y)
+
+    OF = sum(x) - sum(y)
+    verbose,iter_count,is_temperature = verbose_cache
+    if verbose     
+        iter_count[] += 1
+        iter = iter_count[]
+        if is_temperature
+            X = T
+        else
+            X = p
+        end
+        @info "$(__pad_val(iter,4))    $(__pad_val(X,16))   $(__pad_val(OF,16)) $(repr(K,context = :compact => true))"
+    end
+    return OF
+
 end
 
 function update_K_QT!(logp,params)
     p = exp(logp)
-    model,β,T,w,phases,non_inw,vec_cache,dlnϕ_cache = params
-    return update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache)
+    model,β,T,w,phases,non_inw,vec_cache,dlnϕ_cache,verbose = params
+    return update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache,verbose)
 end
 
 function update_K_QP!(Tinv,params)
     T = 1/Tinv
-    model,β,p,w,phases,non_inw,vec_cache,dlnϕ_cache = params
+    model,β,p,w,phases,non_inw,vec_cache,dlnϕ_cache,verbose = params
     update_temperature!(model,T)
-    return update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache)
+    return update_K_QX!(model,p,T,w,β,phases,non_inw,vec_cache,dlnϕ_cache,verbose)
 end
 
 """
@@ -189,12 +204,23 @@ function qp_flash_impl(model,β,p,z,method::RRQXFlash)
     dlnϕ_cache = ∂lnϕ_cache(model, β, p, x, Val{false}())
     vec_cache = (K,lnK)
     #model,p,T,w,β,Kx,phases,non_inw,vec_cache,dlnϕ_cache,spec
-
-    params = (model,β,p,w,phases,non_inw,vec_cache,dlnϕ_cache)
+    verbose = get_verbosity(method)
+    verbose_cache = (get_verbosity(method),Ref(0),true)
+    params = (model,β,p,w,phases,non_inw,vec_cache,dlnϕ_cache,verbose_cache)
     Tinv0 = 1/temperature(flash0)
     prob = Roots.ZeroProblem(update_K_QP!,Tinv0)
+    
+    verbose && @info "_______________________________________________________
+      iter    T                  OF               K"
+
     Tinv = Roots.solve(prob,Roots.Order1(),params,atol = method.atol,rtol = method.rtol)
     T = 1/Tinv
+
+@info "________________________________________________________________________________________
+      Final K values:        $K
+      Final temperature:     $T
+
+"
     n = sum(z)
     resize!(lnK,2)
     resize!(K,2)
@@ -238,12 +264,22 @@ function qt_flash_impl(model::M,β,T,z,method::RRQXFlash) where M
     dlnϕ_cache = ∂lnϕ_cache(model, β, T, x, Val{false}())
     vec_cache = (K,lnK)
     #model,p,T,w,β,Kx,phases,non_inw,vec_cache,dlnϕ_cache,spec
-
-    params = (model,β,T,w,phases,non_inw,vec_cache,dlnϕ_cache)
+    verbose = get_verbosity(method)
+    verbose_cache = (verbose,Ref(0),false)
+    params = (model,β,T,w,phases,non_inw,vec_cache,dlnϕ_cache,verbose_cache)
     logp0 = log(pressure(flash0))
     prob = Roots.ZeroProblem(update_K_QT!,logp0)
+
+    verbose && @info "_______________________________________________________
+      iter    p                  OF               K"
     logp = Roots.solve(prob,Roots.Order1(),params,atol = method.atol,rtol = method.rtol)
     p = exp(logp)
+
+@info "________________________________________________________________________________________
+      Final K values:        $K
+      Final pressure:        $p
+
+"
     n = sum(z)
     resize!(lnK,2)
     resize!(K,2)

--- a/src/methods/property_solvers/multicomponent/tp_flash/RRQXFlash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/RRQXFlash.jl
@@ -216,7 +216,7 @@ function qp_flash_impl(model,β,p,z,method::RRQXFlash)
     Tinv = Roots.solve(prob,Roots.Order1(),params,atol = method.atol,rtol = method.rtol)
     T = 1/Tinv
 
-@info "________________________________________________________________________________________
+    verbose && @info "________________________________________________________________________________________
       Final K values:        $K
       Final temperature:     $T
 

--- a/src/methods/property_solvers/multicomponent/tp_flash/RRQXFlash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/RRQXFlash.jl
@@ -275,7 +275,7 @@ function qt_flash_impl(model::M,β,T,z,method::RRQXFlash) where M
     logp = Roots.solve(prob,Roots.Order1(),params,atol = method.atol,rtol = method.rtol)
     p = exp(logp)
 
-@info "________________________________________________________________________________________
+    verbose && @info "________________________________________________________________________________________
       Final K values:        $K
       Final pressure:        $p
 

--- a/src/methods/property_solvers/multicomponent/tp_flash/electrolyte_flash.jl
+++ b/src/methods/property_solvers/multicomponent/tp_flash/electrolyte_flash.jl
@@ -149,7 +149,9 @@ function tp_flash_michelsen(model::ESElectrolyteModel, p, T, z, method = Michels
     gibbs = one(_1)
     gibbs_dem = one(_1)
     vcache = Ref((_1, _1))
-    verbose && @info "iter  status     β                error(lnK̄)       K̄"
+
+    verbose && @info "_____________________________________________________________________________________
+      iter  status     β                error(lnK̄)       K̄"
     while (error_lnK > K_tol || abs(β_old-β) > 1e-9) && it < itss && status in (RREq,RRLiquid,RRVapour)
         it += 1
         itacc += 1
@@ -247,11 +249,14 @@ function tp_flash_michelsen(model::ESElectrolyteModel, p, T, z, method = Michels
         K̄ .= y ./ x
         β = rachfordrice(K̄, z; non_inx, non_iny, K_tol, verbose)
     end
+verbose &&
+@info "_____________________________________________________________________________________
+      Final K̄ values:        $K̄
+      Final vapour fraction: $β
+      Final value of ψ:      $ψ
 
-    verbose && @info "final K̄ values:        $K̄"
-    verbose && @info "final vapour fraction: $β"
-    verbose && @info "final value of ψ:      $ψ"
-    #convergence checks (TODO, seems to fail with activity models)
+"
+
     status = rachfordrice_status(K̄,z,non_inx,non_iny;K_tol = K_tol)
     verbose && status != RREq && @info "result is single-phase (does not satisfy Rachford-Rice constraints)."
 

--- a/src/models/Activity/equations.jl
+++ b/src/models/Activity/equations.jl
@@ -500,3 +500,12 @@ for xy in [:ph,:ps,:ts,:vt]
         end
     end
 end
+
+for xy in [:qt,:qp]
+    xyz = Symbol(xy,:_flash)
+    @eval begin 
+        function init_preferred_method(method::typeof($xyz),model::ActivityModel,kwargs)
+            return RRQXFlash(;kwargs...)
+        end
+    end
+end

--- a/src/models/Activity/equations.jl
+++ b/src/models/Activity/equations.jl
@@ -491,3 +491,12 @@ function _edge_temperature(model::ActivityModel,p,z,v0 = nothing)
     wrapper = PTFlashWrapper(model,p,NaN,z,:vle)
     return _edge_temperature(wrapper,p,z,v0)
 end
+
+for xy in [:ph,:ps,:ts,:vt]
+    xyz = Symbol(xy,:_flash)
+    @eval begin 
+        function init_preferred_method(method::typeof($xyz),model::ActivityModel,kwargs)
+            return SSXYFlash(;kwargs...)
+        end
+    end
+end

--- a/src/models/Activity/equations.jl
+++ b/src/models/Activity/equations.jl
@@ -496,7 +496,7 @@ for xy in [:ph,:ps,:ts,:vt]
     xyz = Symbol(xy,:_flash)
     @eval begin 
         function init_preferred_method(method::typeof($xyz),model::ActivityModel,kwargs)
-            return SSXYFlash(;kwargs...)
+            return RRXYFlash(;kwargs...)
         end
     end
 end

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -509,7 +509,7 @@ for xy in [:ph,:ps,:ts,:vt]
     xyz = Symbol(xy,:_flash)
     @eval begin 
         function init_preferred_method(method::typeof($xyz),model::RestrictedEquilibriaModel,kwargs)
-            return SSXYFlash(;kwargs...)
+            return RRXYFlash(;kwargs...)
         end
     end
 end

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -514,4 +514,13 @@ for xy in [:ph,:ps,:ts,:vt]
     end
 end
 
+for xy in [:qt, :qp]
+    xyz = Symbol(xy,:_flash)
+    @eval begin 
+        function init_preferred_method(method::typeof($xyz),model::RestrictedEquilibriaModel,kwargs)
+            return RRQXFlash(;kwargs...)
+        end
+    end
+end
+
 export CompositeModel

--- a/src/models/CompositeModel/CompositeModel.jl
+++ b/src/models/CompositeModel/CompositeModel.jl
@@ -407,20 +407,15 @@ saturation_model(model::CompositeModel) = model.fluid
 
 #defer bubbledew eq to the fluid field
 
-function init_preferred_method(method::typeof(bubble_pressure),model::CompositeModel,kwargs)
-    init_preferred_method(method,model.fluid,kwargs)
-end
+for prop in [:bubble_pressure,:bubble_temperature,
+    :dew_pressure,:dew_temperature,
+    :tp_flash,:ph_flash,:vt_flash,:ts_flash,:ps_flash]
 
-function init_preferred_method(method::typeof(bubble_temperature),model::CompositeModel,kwargs)
-    init_preferred_method(method,model.fluid,kwargs)
-end
-
-function init_preferred_method(method::typeof(dew_pressure),model::CompositeModel,kwargs)
-    init_preferred_method(method,model.fluid,kwargs)
-end
-
-function init_preferred_method(method::typeof(dew_temperature),model::CompositeModel,kwargs)
-    init_preferred_method(method,model.fluid,kwargs)
+    @eval begin
+        function init_preferred_method(method::typeof($prop),model::CompositeModel,kwargs)
+            init_preferred_method(method,model.fluid,kwargs)
+        end
+    end
 end
 
 function bubble_pressure(model::CompositeModel, T, x, method::ThermodynamicMethod)
@@ -439,10 +434,6 @@ function dew_temperature(model::CompositeModel, T, x, method::ThermodynamicMetho
     return dew_temperature(model.fluid, T, x, method)
 end
 
-#Michelsen TPFlash and Rachford-Rice TPFlash support
-function init_preferred_method(method::typeof(tp_flash),model::CompositeModel{<:Any,Nothing},kwargs)
-    init_preferred_method(method,model.fluid,kwargs)
-end
 
 __tpflash_cache_model(model::CompositeModel{<:Any,Nothing},p,T,z,equilibrium) = __tpflash_cache_model(model.fluid,p,T,z,equilibrium)
 
@@ -512,6 +503,15 @@ end
 function _edge_temperature(model::RestrictedEquilibriaModel,p,z,v0 = nothing)
     wrapper = __tpflash_cache_model(model,p,NaN,z,:vle)
     return _edge_temperature(wrapper,p,z,v0)
+end
+
+for xy in [:ph,:ps,:ts,:vt]
+    xyz = Symbol(xy,:_flash)
+    @eval begin 
+        function init_preferred_method(method::typeof($xyz),model::RestrictedEquilibriaModel,kwargs)
+            return SSXYFlash(;kwargs...)
+        end
+    end
 end
 
 export CompositeModel

--- a/src/models/utility/PTFlashWrapper.jl
+++ b/src/models/utility/PTFlashWrapper.jl
@@ -159,3 +159,13 @@ end
 function K0_lle_init(wrapper::PTFlashWrapper,p,T,z,cache = tpd_cache(wrapper,p,T,z);reduced = true)
     return K0_lle_init(__γ_unwrap(wrapper),p,T,z,cache;reduced)
 end
+
+function update_volume!(model::PTFlashWrapper,result,p = pressure(result),T = temperature(result))
+    for i in 1:numphases(result)
+        phase_i = identify_phase(result,i)
+        if is_unknown(phase_i) || is_liquid(phase_i)
+            result.volumes[i] = volume(model,p,T,result.compositions[i],phase = phase_i)
+        end
+    end
+    return nothing
+end

--- a/src/models/utility/PTFlashWrapper.jl
+++ b/src/models/utility/PTFlashWrapper.jl
@@ -169,3 +169,21 @@ function update_volume!(model::PTFlashWrapper,result,p = pressure(result),T = te
     end
     return nothing
 end
+
+for xy in [:ph,:ps,:ts,:vt]
+    xyz = Symbol(xy,:_flash)
+    @eval begin 
+        function init_preferred_method(method::typeof($xyz),model::PTFlashWrapper,kwargs)
+            return RRXYFlash(;kwargs...)
+        end
+    end
+end
+
+for xy in [:qt, :qp]
+    xyz = Symbol(xy,:_flash)
+    @eval begin 
+        function init_preferred_method(method::typeof($xyz),model::PTFlashWrapper,kwargs)
+            return RRQXFlash(;kwargs...)
+        end
+    end
+end

--- a/src/modules/solvers/nlsolve.jl
+++ b/src/modules/solvers/nlsolve.jl
@@ -206,3 +206,198 @@ function roots_nlsolve(f::F,x0::Number,method::Roots.AbstractHalleyLikeMethod,op
     prob = Roots.ZeroProblem(to_halley(f),x0)
     sol = Roots.solve(prob,method)
 end
+
+#iterative solver
+
+function solve1_update_state(state, x, fx; full_iter=true)
+    xs, fxs, damp, status = state
+    x1, x2, x3 = xs
+    f1, f2, f3 = fxs
+
+    if status == :no_init
+        return ((x, x2, x3), (fx, f2, f3), damp, :iter0)
+
+    elseif status == :iter0
+        return ((x, x1, x2), (fx, f1, f2), damp, :iter_initial)
+
+    elseif status == :iter_initial
+        new_damp = max(zero(damp), damp - 0.2)
+        new_status = iszero(new_damp) ? :iter_full : :iter_initial
+        return ((x, x1, x2), (fx, f1, f2), new_damp, new_status)
+
+    elseif status == :iter_full
+        # Only attempt to establish a bracket when fx is a reliable evaluation
+        if full_iter
+            if fx * f1 < 0
+                na, nb, nfa, nfb = Roots.sort_smallest(x, x1, fx, f1)
+                # c: best of the two remaining points
+                nc, nfc = abs(f2) <= abs(f3) ? (x2, f2) : (x3, f3)
+                return ((na, nb, nc), (nfa, nfb, nfc), damp, :bounded)
+            elseif fx * f2 < 0
+                na, nb, nfa, nfb = Roots.sort_smallest(x, x2, fx, f2)
+                nc, nfc = abs(f1) <= abs(f3) ? (x1, f1) : (x3, f3)
+                return ((na, nb, nc), (nfa, nfb, nfc), damp, :bounded)
+            elseif fx * f3 < 0
+                na, nb, nfa, nfb = Roots.sort_smallest(x, x3, fx, f3)
+                nc, nfc = abs(f1) <= abs(f2) ? (x1, f1) : (x2, f2)
+                return ((na, nb, nc), (nfa, nfb, nfc), damp, :bounded)
+            end
+        end
+
+        # No bracket found, or full_iter=false: maintain 3 best points sorted by x.
+        _, imax = findmax((abs(f1),abs(f2),abs(f3)))
+        keep = if imax == 1
+            ((x2, f2), (x3, f3), (x, fx))
+        elseif imax == 2
+            ((x1, f1), (x3, f3), (x, fx))
+        else
+            ((x1, f1), (x2, f2), (x, fx))
+        end
+        w1, w2, w3 = sort(keep)
+        return ((w1[1], w2[1], w3[1]), (w1[2], w2[2], w3[2]), damp, :iter_full)
+
+    elseif status == :bounded
+        a, b, c = x1, x2, x3
+        fa, fb, fc = f1, f2, f3
+        # Invariant: fa*fb < 0, |fa| <= |fb|, c is the previously displaced endpoint.
+
+        if !full_iter
+            # fx is approximate: don't risk corrupting the bracket.
+            # Only update c if the new point is strictly better, otherwise hold.
+            if abs(fx) < abs(fc)
+                return ((a, b, x), (fa, fb, fx), damp, :bounded)
+            else
+                return state
+            end
+        end
+
+        # Fix: correctly track which endpoint gets displaced.
+        # The displaced endpoint (the one leaving the bracket) becomes the new c,
+        # which is what gives Chandrapatla's ξ and ϕ their meaning.
+        if fx * fa < 0
+            # New bracket: (x, a). Old b leaves → new c = b.
+            na, nb, nfa, nfb = Roots.sort_smallest(x, a, fx, fa)
+            return ((na, nb, b), (nfa, nfb, fb), damp, :bounded)
+        elseif fx * fb < 0
+            # New bracket: (x, b). Old a leaves → new c = a.
+            na, nb, nfa, nfb = Roots.sort_smallest(x, b, fx, fb)
+            return ((na, nb, a), (nfa, nfb, fa), damp, :bounded)
+        else
+            # fa*fb < 0 by invariant, so x must bracket with one side.
+            # Reaching here means fx ≈ 0 or a noisy evaluation slipped through.
+            # Guard: update c only if the new point is better than what we have.
+            if abs(fx) < abs(fc)
+                return ((a, b, x), (fa, fb, fx), damp, :bounded)
+            else
+                return state
+            end
+        end
+
+    else
+        return state
+    end
+end
+
+
+function solve1_new_iter(old_state,x,fx,dfx = nothing;full_iter = true)
+    ∂fx = dfx == nothing ? fx : oftype(fx,dfx)
+    state = solve1_update_state(old_state,x,fx;full_iter)
+    xx,fxx,α,status = state
+    if status == :iter0
+        if dfx == nothing
+            x0 = x
+        else
+            x0 = (x - (1 - α)*f/∂fx)
+        end
+        return x0,state
+    elseif status == :iter_initial
+        xa,xb,_ = xx
+        fa,fb,_ = fxx
+        dfdx = dfx == nothing ? ((fb - fa)/(xb - xa)) : ∂fx   
+        xnew = (xa - (1 - α)*fa/dfdx)
+        return xnew,state
+    elseif status == :iter_full
+        x1, x2, x3 = xx
+        f1, f2, f3 = fxx
+        if full_iter
+            xnew = Roots.inverse_quadratic_step(x1, x2, x3, f1, f2, f3)
+            xlo, xhi = extrema((x1,x2,x3))
+            span = xhi - xlo
+            if !(xlo - span < xnew < xhi + span)
+                dfdx = dfx == nothing ? ((f2 - f1) / (x2 - x1)) : ∂fx
+                xnew = x1 - f1 / dfdx
+            end
+        else
+            dfdx = dfx == nothing ? ((f2 - f1) / (x2 - x1)) : ∂fx
+            xnew = x1 - f1 / dfdx
+        end
+
+        if f1*f2 < 0
+            if x1 < x2
+                xlo,xhi,flo,fhi = x1,x2,f1,f2
+            else
+                xlo,xhi,flo,fhi = x2,x1,f2,f1
+            end
+            if !(xlo <= xnew <= xhi)
+                xm = 0.5*(xlo + xhi)
+                xrf = (fb * a - fa * b) / (fb - fa)
+
+            if xlo < xrf < xhi
+                # Check Illinois adjustment: if regula falsi keeps one side fixed,
+                # the Illinois half-weight step can do better.
+                fa_ill = fa / 2
+                xill = ((fb) * a - fa_ill * b) / (fb - fa_ill)
+                xnew = (xlo < xill < xhi) ? xill : xrf
+            else
+                xnew = xm  # regula falsi left the bracket, bisect
+            end
+            end
+        end
+
+        return xnew, state
+    elseif status == :bounded
+        a, b, c = xx
+        fa, fb, fc = fxx
+        # a is best (|fa| <= |fb|), [a,b] is the bracket, c is displaced endpoint.
+
+        xlo, xhi = minmax(a, b)
+        xm = (a + b) / 2  # bisection
+
+        # Chandrapatla's condition: IQI is interpolating (not extrapolating).
+        ξ = (a - b) / (c - b)
+        ϕ = (fa - fb) / (fc - fb)
+        ϕ² = ϕ^2
+        Δ = (ϕ² < ξ) && (1 - 2ϕ + ϕ² < 1 - ξ)
+
+        if Δ
+            xnew = Roots.inverse_quadratic_step(a, b, c, fa, fb, fc)
+            # Guard: IQI must land strictly inside the bracket.
+            if !(xlo < xnew < xhi)
+                xnew = xm
+            end
+        else
+            # Illinois step: modify the regula falsi weight at the retained endpoint
+            # to avoid one-sided stagnation, then guard it. Falls back to bisection.
+            #
+            # Standard regula falsi: xrf = (fb*a - fa*b) / (fb - fa)
+            # Illinois: halve the function value at whichever endpoint is retained.
+            # If the new point lands on the same side as a (the best point),
+            # the retained endpoint is b, so we use fb/2 in the formula.
+            xrf = (fb * a - fa * b) / (fb - fa)
+
+            if xlo < xrf < xhi
+                # Check Illinois adjustment: if regula falsi keeps one side fixed,
+                # the Illinois half-weight step can do better.
+                fa_ill = fa / 2
+                xill = ((fb) * a - fa_ill * b) / (fb - fa_ill)
+                xnew = (xlo < xill < xhi) ? xill : xrf
+            else
+                xnew = xm  # regula falsi left the bracket, bisect
+            end
+        end
+        return xnew, state
+    else
+        return first(xx)*NaN,state
+    end
+    return first(xx)*NaN,state
+end

--- a/src/modules/solvers/nlsolve.jl
+++ b/src/modules/solvers/nlsolve.jl
@@ -209,21 +209,26 @@ end
 
 #iterative solver
 
+function solve1_initial_state(::Type{T},α = convert(T,0.6)) where T
+    nan = convert(T,NaN)
+    return ((nan,nan,nan),(nan,nan,nan),α,:iter0)
+end
+
 function solve1_update_state(state, x, fx; full_iter=true)
-    xs, fxs, damp, status = state
+    xs, fxs, α, status = state
     x1, x2, x3 = xs
     f1, f2, f3 = fxs
 
     if status == :no_init
-        return ((x, x2, x3), (fx, f2, f3), damp, :iter0)
+        return ((x, x2, x3), (fx, f2, f3), α, :iter0)
 
     elseif status == :iter0
-        return ((x, x1, x2), (fx, f1, f2), damp, :iter_initial)
+        return ((x, x1, x2), (fx, f1, f2), α, :iter_initial)
 
     elseif status == :iter_initial
-        new_damp = max(zero(damp), damp - 0.2)
-        new_status = iszero(new_damp) ? :iter_full : :iter_initial
-        return ((x, x1, x2), (fx, f1, f2), new_damp, new_status)
+        new_α = max(zero(α), α - 0.2)
+        new_status = iszero(new_α) ? :iter_full : :iter_initial
+        return ((x, x1, x2), (fx, f1, f2), new_α, new_status)
 
     elseif status == :iter_full
         # Only attempt to establish a bracket when fx is a reliable evaluation
@@ -232,15 +237,15 @@ function solve1_update_state(state, x, fx; full_iter=true)
                 na, nb, nfa, nfb = Roots.sort_smallest(x, x1, fx, f1)
                 # c: best of the two remaining points
                 nc, nfc = abs(f2) <= abs(f3) ? (x2, f2) : (x3, f3)
-                return ((na, nb, nc), (nfa, nfb, nfc), damp, :bounded)
+                return ((na, nb, nc), (nfa, nfb, nfc), α, :bounded)
             elseif fx * f2 < 0
                 na, nb, nfa, nfb = Roots.sort_smallest(x, x2, fx, f2)
                 nc, nfc = abs(f1) <= abs(f3) ? (x1, f1) : (x3, f3)
-                return ((na, nb, nc), (nfa, nfb, nfc), damp, :bounded)
+                return ((na, nb, nc), (nfa, nfb, nfc), α, :bounded)
             elseif fx * f3 < 0
                 na, nb, nfa, nfb = Roots.sort_smallest(x, x3, fx, f3)
                 nc, nfc = abs(f1) <= abs(f2) ? (x1, f1) : (x2, f2)
-                return ((na, nb, nc), (nfa, nfb, nfc), damp, :bounded)
+                return ((na, nb, nc), (nfa, nfb, nfc), α, :bounded)
             end
         end
 
@@ -254,7 +259,7 @@ function solve1_update_state(state, x, fx; full_iter=true)
             ((x1, f1), (x2, f2), (x, fx))
         end
         w1, w2, w3 = sort(keep)
-        return ((w1[1], w2[1], w3[1]), (w1[2], w2[2], w3[2]), damp, :iter_full)
+        return ((w1[1], w2[1], w3[1]), (w1[2], w2[2], w3[2]), α, :iter_full)
 
     elseif status == :bounded
         a, b, c = x1, x2, x3
@@ -265,7 +270,7 @@ function solve1_update_state(state, x, fx; full_iter=true)
             # fx is approximate: don't risk corrupting the bracket.
             # Only update c if the new point is strictly better, otherwise hold.
             if abs(fx) < abs(fc)
-                return ((a, b, x), (fa, fb, fx), damp, :bounded)
+                return ((a, b, x), (fa, fb, fx), α, :bounded)
             else
                 return state
             end
@@ -277,17 +282,17 @@ function solve1_update_state(state, x, fx; full_iter=true)
         if fx * fa < 0
             # New bracket: (x, a). Old b leaves → new c = b.
             na, nb, nfa, nfb = Roots.sort_smallest(x, a, fx, fa)
-            return ((na, nb, b), (nfa, nfb, fb), damp, :bounded)
+            return ((na, nb, b), (nfa, nfb, fb), α, :bounded)
         elseif fx * fb < 0
             # New bracket: (x, b). Old a leaves → new c = a.
             na, nb, nfa, nfb = Roots.sort_smallest(x, b, fx, fb)
-            return ((na, nb, a), (nfa, nfb, fa), damp, :bounded)
+            return ((na, nb, a), (nfa, nfb, fa), α, :bounded)
         else
             # fa*fb < 0 by invariant, so x must bracket with one side.
             # Reaching here means fx ≈ 0 or a noisy evaluation slipped through.
             # Guard: update c only if the new point is better than what we have.
             if abs(fx) < abs(fc)
-                return ((a, b, x), (fa, fb, fx), damp, :bounded)
+                return ((a, b, x), (fa, fb, fx), α, :bounded)
             else
                 return state
             end

--- a/src/modules/solvers/nlsolve.jl
+++ b/src/modules/solvers/nlsolve.jl
@@ -252,11 +252,11 @@ function solve1_update_state(state, x, fx; full_iter=true)
         # No bracket found, or full_iter=false: maintain 3 best points sorted by x.
         _, imax = findmax((abs(f1),abs(f2),abs(f3)))
         keep = if imax == 1
-            ((x2, f2), (x3, f3), (x, fx))
+            SVector((x2, f2), (x3, f3), (x, fx))
         elseif imax == 2
-            ((x1, f1), (x3, f3), (x, fx))
+            SVector((x1, f1), (x3, f3), (x, fx))
         else
-            ((x1, f1), (x2, f2), (x, fx))
+            SVector((x1, f1), (x2, f2), (x, fx))
         end
         w1, w2, w3 = sort(keep)
         return ((w1[1], w2[1], w3[1]), (w1[2], w2[2], w3[2]), α, :iter_full)

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -205,14 +205,12 @@ end
 viewlast(x,i) = @view(x[(end - i + 1):end])
 viewfirst(x,i) = @view(x[begin:i])
 viewlast(x,i,n) = viewfirst(viewlast(x,i),n)
-
 linearidx(x::AbstractVector) = LinearIndices(x)
+mid(a,b,c) =  max(min(a,b),min(max(a,b),c))
+deleteat(x,i) = deleteat!(copy(x),i)
 
 if Base.VERSION < v"1.11"
     linearidx(x::AbstractMatrix) = diagind(x,0)
 else
     linearidx(x::AbstractMatrix) = diagind(x,0,IndexStyle(x))
 end
-
-mid(a,b,c) =  max(min(a,b),min(max(a,b),c))
-deleteat(x,i) = deleteat!(copy(x),i)

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -588,6 +588,61 @@ end
     end =#
 end
 
+@testset "XY flash (activity models)" begin
+    model = UNIFAC(["ethanol","water"], puremodel = PR)
+    x = [0.1, 0.9]
+    T_bub = 360.0
+    p, = bubble_pressure(model, T_bub, x)
+    h_liq = enthalpy(model, p, T_bub, x; phase = :liquid)
+    h_gas = enthalpy(model, p, T_bub, x; phase = :gas)
+
+    # two-phase: enthalpy between bubble and dew enthalpies
+    hmix = (h_liq + h_gas) / 2
+    res_2ph = ph_flash(model, p, hmix, x)
+    @test Clapeyron.numphases(res_2ph) == 2
+    @test enthalpy(model, res_2ph) ≈ hmix rtol = 1e-6
+
+    # single-phase liquid
+    h_sub = enthalpy(model, p, 350.0, x; phase = :liquid)
+    res_liq = ph_flash(model, p, h_sub, x)
+    @test Clapeyron.numphases(res_liq) == 1
+    @test Clapeyron.temperature(res_liq) ≈ 350.0 rtol = 1e-6
+
+    # single-phase gas
+    h_sup = enthalpy(model, p, 380.0, x; phase = :gas)
+    res_gas = ph_flash(model, p, h_sup, x)
+    @test Clapeyron.numphases(res_gas) == 1
+    @test Clapeyron.temperature(res_gas) ≈ 380.0 rtol = 1e-6
+
+    # ps_flash: same T as ph_flash when using consistent s specification
+    s_2ph = entropy(model, res_2ph)
+    res_ps = ps_flash(model, p, s_2ph, x)
+    @test Clapeyron.numphases(res_ps) == 2
+    @test Clapeyron.temperature(res_ps) ≈ Clapeyron.temperature(res_2ph) rtol = 1e-6
+end
+
+@testset "XY flash (activity models, LLE)" begin
+    model = UNIFAC(["water","hexane"])
+    x = [0.5, 0.5]
+    p = 101325.0
+    T_lle = 303.15
+
+    # build a consistent two-phase target from the existing PT LLE flash path
+    flash_lle = Clapeyron.tp_flash2(model, p, T_lle, x, MichelsenTPFlash(equilibrium = :lle))
+    h_2ph = enthalpy(model, flash_lle; equilibrium = :lle)
+
+    res_2ph = ph_flash(model, p, h_2ph, x; equilibrium = :lle)
+    @test Clapeyron.numphases(res_2ph) == 2
+    @test Clapeyron.temperature(res_2ph) ≈ T_lle rtol = 1e-6
+    @test enthalpy(model, res_2ph; equilibrium = :lle) ≈ h_2ph rtol = 1e-6
+
+    # ps_flash with :lle should recover the same T as the two-phase ph_flash
+    s_2ph = entropy(model, res_2ph; equilibrium = :lle)
+    res_ps = ps_flash(model, p, s_2ph, x; equilibrium = :lle)
+    @test Clapeyron.numphases(res_ps) == 2
+    @test Clapeyron.temperature(res_ps) ≈ Clapeyron.temperature(res_2ph) rtol = 1e-6
+end
+
 @testset "Saturation Methods" begin
     model = PR(["water"])
     vdw = vdW(["water"])

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -629,16 +629,17 @@ end
 
     # build a consistent two-phase target from the existing PT LLE flash path
     flash_lle = Clapeyron.tp_flash2(model, p, T_lle, x, MichelsenTPFlash(equilibrium = :lle))
-    h_2ph = enthalpy(model, flash_lle; equilibrium = :lle)
+    h_2ph = enthalpy(model, flash_lle)
 
     res_2ph = ph_flash(model, p, h_2ph, x; equilibrium = :lle)
+    @test res_2ph.data.vapour_idx == -1
     @test Clapeyron.numphases(res_2ph) == 2
     @test Clapeyron.temperature(res_2ph) ≈ T_lle rtol = 1e-6
-    @test enthalpy(model, res_2ph; equilibrium = :lle) ≈ h_2ph rtol = 1e-6
+    @test enthalpy(model, res_2ph) ≈ h_2ph rtol = 1e-6
 
     # ps_flash with :lle should recover the same T as the two-phase ph_flash
     s_2ph = entropy(model, res_2ph; equilibrium = :lle)
-    res_ps = ps_flash(model, p, s_2ph, x; equilibrium = :lle)
+    res_ps = ps_flash(model, p, s_2ph, x)
     @test Clapeyron.numphases(res_ps) == 2
     @test Clapeyron.temperature(res_ps) ≈ Clapeyron.temperature(res_2ph) rtol = 1e-6
 end

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -639,7 +639,7 @@ end
 
     # ps_flash with :lle should recover the same T as the two-phase ph_flash
     s_2ph = entropy(model, res_2ph)
-    res_ps = ps_flash(model, p, s_2ph, x)
+    res_ps = ps_flash(model, p, s_2ph, x, equilibrium = :lle)
     @test Clapeyron.numphases(res_ps) == 2
     @test Clapeyron.temperature(res_ps) ≈ Clapeyron.temperature(res_2ph) rtol = 1e-6
 end

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -638,7 +638,7 @@ end
     @test enthalpy(model, res_2ph) ≈ h_2ph rtol = 1e-6
 
     # ps_flash with :lle should recover the same T as the two-phase ph_flash
-    s_2ph = entropy(model, res_2ph; equilibrium = :lle)
+    s_2ph = entropy(model, res_2ph)
     res_ps = ps_flash(model, p, s_2ph, x)
     @test Clapeyron.numphases(res_ps) == 2
     @test Clapeyron.temperature(res_ps) ≈ Clapeyron.temperature(res_2ph) rtol = 1e-6


### PR DESCRIPTION
Supercedes #572, implements a flash method (`RRXYFlash`) with an structure based on the fugacity bubbledew solvers: the outer solver is a root finder in p/T, the inner solver is a rachford-rice update. With this solver (in addition to `RRQXFlash`) activity and composite models now support all available 2-phase flashes that we currently provide.

Most of the work was already done in master and was based on what was needed to make #572 work.

Some changes to the `FlashResult` api:
- We now store the index of the vapour phase in the `data` field. This helps when evaluating properties on activity models. The index is an `Int` that is greater than zero on flashes with vapour phase, zero when no phase was determined, and negative when there is no vapour phase. Instead of doing this by hand, the accessor `identify_phase(result::FlashResult, i)::symbol` is implemented.
- Evaluating properties on a `FlashResult` required a rework on `PT_property`. Now, the last argument of that function is the volume of the model at the conditions (if calculated and finite).
- For the `px` and `tx` initial points, if the suggested phase is liquid and the method suggests LLE equilibrium, we now test for said LLE.

Cc: @se-schmitt 