### PR TITLE
Fix type stability in dew/bubble point solvers and ChemPot methods

### DIFF
--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -446,7 +446,8 @@ function bubble_pressure(model::EoSModel, T, x, method::ThermodynamicMethod)
     model_r,idx_r = index_reduction(model,x)
     if length(model_r)==1 && !is_pseudo_pure(model)
         (P_sat,v_l,v_v) = saturation_pressure(model_r,T)
-        return (P_sat,v_l,v_v,x)
+        y = [one(eltype(x))]
+        return (P_sat,v_l,v_v,y)
     end
     x_r = x[idx_r]
 
@@ -475,7 +476,7 @@ vl = $(primalval(v_l))
 vv = $(primalval(v_v))
 y  = $(primalval(y))"
 
-verbose && !converged && @info "bubble_pressure: convergence checks failed."
+    verbose && !converged && @info "bubble_pressure: convergence checks failed."
 
     if converged
         return (P_sat, v_l, v_v, y)
@@ -646,9 +647,10 @@ function bubble_temperature(model::EoSModel, p, x, method::ThermodynamicMethod)
     p = float(p)
     verbose = get_verbosity(method)
     model_r,idx_r = index_reduction(model,x)
-    if length(model_r)==1 && !is_pseudo_pure(model)
+    if length(model_r) == 1 && !is_pseudo_pure(model)
         (T_sat,v_l,v_v) = saturation_temperature(model_r,p)
-        return (T_sat,v_l,v_v,x)
+        y = [one(eltype(x))]
+        return (T_sat,v_l,v_v,y)
     end
     x_r = x[idx_r]
 
@@ -677,8 +679,7 @@ vl = $(primalval(v_l))
 vv = $(primalval(v_v))
 y  = $(primalval(y))"
 
-verbose && !converged && @info "bubble_temperature: convergence checks failed."
-
+    verbose && !converged && @info "bubble_temperature: convergence checks failed."
 
     if converged
         return (T_sat, v_l, v_v, y)

--- a/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
@@ -47,7 +47,7 @@ function ChemPotBubblePressure(;vol0 = nothing,
                                 verbose = false)
 
     if p0 == y0 == vol0 == nothing
-        return ChemPotBubblePressure{Nothing}(vol0,p0,y0,nonvolatiles,f_limit,atol,rtol,max_iters,verbose)
+        return ChemPotBubblePressure{Float64}(vol0,p0,y0,nonvolatiles,f_limit,atol,rtol,max_iters,verbose)
     elseif (p0 == y0 == nothing) && !isnothing(vol0)
         vl,vv = promote(vol0[1],vol0[2])
         return ChemPotBubblePressure{typeof(vl)}(vol0,p0,y0,nonvolatiles,f_limit,atol,rtol,max_iters,verbose)
@@ -194,7 +194,7 @@ function ChemPotBubbleTemperature(;vol0 = nothing,
     verbose = false)
 
     if T0 == y0 == vol0 == nothing
-        return ChemPotBubbleTemperature{Nothing}(vol0,T0,y0,nonvolatiles,f_limit,atol,rtol,max_iters,verbose)
+        return ChemPotBubbleTemperature{Float64}(vol0,T0,y0,nonvolatiles,f_limit,atol,rtol,max_iters,verbose)
     elseif (T0 == y0 == nothing) && !isnothing(vol0)
         vl,vv = promote(vol0[1],vol0[2])
         return ChemPotBubbleTemperature{typeof(vl)}(vol0,T0,y0,nonvolatiles,f_limit,atol,rtol,max_iters,verbose)

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -141,7 +141,8 @@ function dew_pressure(model::EoSModel, T, y, method::ThermodynamicMethod)
     model_r,idx_r = index_reduction(model,y)
     if length(model_r) == 1 && !is_pseudo_pure(model)
         (P_sat,v_l,v_v) = saturation_pressure(model_r,T)
-        return (P_sat,v_l,v_v,y)
+        x = [one(eltype(y))]
+        return (P_sat,v_l,v_v,x)
     end
     y_r = y[idx_r]
 
@@ -170,7 +171,7 @@ vl = $(primalval(v_l))
 vv = $(primalval(v_v))
 x  = $(primalval(x))"
 
-verbose && !converged && @info "dew_pressure: convergence checks failed."
+    verbose && !converged && @info "dew_pressure: convergence checks failed."
 
     if converged
         return (P_sat, v_l, v_v, x)
@@ -343,9 +344,10 @@ function dew_temperature(model::EoSModel,p,y,method::ThermodynamicMethod)
     p = float(p)
     verbose = get_verbosity(method)
     model_r,idx_r = index_reduction(model,y)
-    if length(model_r)==1 && !is_pseudo_pure(model)
+    if length(model_r) == 1 && !is_pseudo_pure(model)
         (T_sat,v_l,v_v) = saturation_temperature(model_r,p)
-        return (T_sat,v_l,v_v,y)
+        x = [one(eltype(y))]
+        return (T_sat,v_l,v_v,x)
     end
     y_r = y[idx_r]
 
@@ -374,7 +376,7 @@ vl = $(primalval(v_l))
 vv = $(primalval(v_v))
 x  = $(primalval(x))"
 
-verbose && !converged && @info "dew_temperature: convergence checks failed."
+    verbose && !converged && @info "dew_temperature: convergence checks failed."
 
     if converged
         return (T_sat, v_l, v_v, x)

--- a/src/methods/property_solvers/multicomponent/dew_point/dew_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point/dew_chempot.jl
@@ -45,7 +45,7 @@ function ChemPotDewPressure(;vol0 = nothing,
                                 verbose = false)
 
     if p0 == x0 == vol0 == nothing
-        return ChemPotDewPressure{Nothing}(vol0,p0,x0,noncondensables,f_limit,atol,rtol,max_iters,verbose)
+        return ChemPotDewPressure{Float64}(vol0,p0,x0,noncondensables,f_limit,atol,rtol,max_iters,verbose)
     elseif (p0 == x0 == nothing) && !isnothing(vol0)
         vl,vv = promote(vol0[1],vol0[2])
         return ChemPotDewPressure{typeof(vl)}(vol0,p0,x0,noncondensables,f_limit,atol,rtol,max_iters,verbose)
@@ -181,7 +181,7 @@ function ChemPotDewTemperature(;vol0 = nothing,
     verbose = false)
 
     if T0 == x0 == vol0 == nothing
-        return ChemPotDewTemperature{Nothing}(vol0,T0,x0,noncondensables,f_limit,atol,rtol,max_iters,verbose)
+        return ChemPotDewTemperature{Float64}(vol0,T0,x0,noncondensables,f_limit,atol,rtol,max_iters,verbose)
     elseif (T0 == x0 == nothing) && !isnothing(vol0)
         vl,vv = promote(vol0[1],vol0[2])
         return ChemPotDewTemperature{typeof(vl)}(vol0,T0,x0,noncondensables,f_limit,atol,rtol,max_iters,verbose)


### PR DESCRIPTION
The problem was identified with `@code_warntype` while tracing `dew_temperature` on a single-component case.

## Minimal reproducer

```julia
using Clapeyron
using InteractiveUtils

fluid = cPR(["cyclopentane"], idealmodel = ReidIdeal)
z = Clapeyron.SA[1.0]
p = 167855.58754210806
T = 338.1499999998127

method_empty = Clapeyron.ChemPotDewTemperature()

@code_warntype Clapeyron.dew_temperature(fluid, p, z)
@code_warntype Clapeyron.dew_temperature(fluid, p, z, method_empty)
```

## Evidence before the fix

Two separate issues were responsible for the instability.

### 1. Empty `ChemPot*` constructors defaulted to `T = Nothing`

For example, `ChemPotDewTemperature()` constructed a method object with type parameter `Nothing`. That made the stored fields look like this:

```julia
vol0::Union{Nothing,Tuple{Nothing,Nothing}}
x0::Union{Nothing,Vector{Nothing}}
```

This polluted inference in the initialization path. Across the function boundary, the compiler had to treat cases like "x0 may really be a `Vector{Nothing}`" and "vol0 may really be a `Tuple{Nothing,Nothing}`" as live possibilities. That forced `dew_temperature_init(...)` to carry `Nothing`-tainted union types in its inferred return value, which then propagated into local variables such as `vl`, `vv`, `x0`, and the packed state vector `v0`.

### 2. The pure-component fast path returned a different composition container

In the dew and bubble shortcuts for the single-component case, the fourth return value was the input composition itself:

```julia
return (P_sat, v_l, v_v, y)
return (T_sat, v_l, v_v, y)
return (P_sat, v_l, v_v, x)
return (T_sat, v_l, v_v, x)
```

That was inconsistent with the normal branch, which rebuilds and returns the phase composition through the regular solver path. With a static input such as `SVector{1,Float64}`, this also split the return type: the pure fast path returned the original `SVector`, while the normal path returned `Vector{Float64}`. Because the branch condition is only known at run time, the compiler had to infer the fourth return value as `Union{SVector{1,Float64},Vector{Float64}}`, which in turn made the full return tuple type-unstable.

## What was changed

This patch makes two targeted fixes.

### 1. Default `ChemPot*` constructors now use `Float64`

The empty constructors now return:

```julia
ChemPotDewPressure{Float64}()
ChemPotDewTemperature{Float64}()
ChemPotBubblePressure{Float64}()
ChemPotBubbleTemperature{Float64}()
```

This removes the `Nothing`-typed storage from the default initialization path.

### 2. Pure-component fast paths now return the correct phase composition

The four single-component shortcuts now return:

```julia
x = [one(eltype(y))]
y = [one(eltype(x))]
```

This does two things:

- keeps the return shape consistent with the normal branch;
- fixes the dew-path semantics by returning `x` instead of `y`.

No extra `length(y) == 1` or `length(x) == 1` dispatch shortcut was added in this revision.

## Evidence after the fix

The default method objects are now concrete:

```julia
typeof(Clapeyron.ChemPotDewPressure())      == ChemPotDewPressure{Float64}
typeof(Clapeyron.ChemPotDewTemperature())   == ChemPotDewTemperature{Float64}
typeof(Clapeyron.ChemPotBubblePressure())   == ChemPotBubblePressure{Float64}
typeof(Clapeyron.ChemPotBubbleTemperature())== ChemPotBubbleTemperature{Float64}
```

The four top-level APIs now return a single concrete type in the tested single-component case:

```julia
typeof(Clapeyron.dew_pressure(fluid, T, z))
typeof(Clapeyron.dew_temperature(fluid, p, z))
typeof(Clapeyron.bubble_pressure(fluid, T, z))
typeof(Clapeyron.bubble_temperature(fluid, p, z))
```

All four evaluate to:

```julia
Tuple{Float64, Float64, Float64, Vector{Float64}}
```

This confirms that the interface is type-stable for the reproduced case.
