### PR TITLE
fix #602

### DIFF
--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -443,8 +443,7 @@ function bubble_pressure(model::EoSModel, T, x, method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,x)
     if length(_model_r)==1 && !is_pseudo_pure(model)
         (P_sat,v_l,v_v) = saturation_pressure(_model_r,T)
-        y = [one(eltype(x))]
-        return (P_sat,v_l,v_v,y)
+        return (P_sat,v_l,v_v,Vector{eltype(x)}(x))
     end
     x_r = x[idx_r]
     model_r = __tpflash_cache_model(_model_r,NaN,T,x,:vle)
@@ -643,8 +642,7 @@ function bubble_temperature(model::EoSModel, p, x, method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,x)
     if length(_model_r) == 1 && !is_pseudo_pure(model)
         (T_sat,v_l,v_v) = saturation_temperature(_model_r,p)
-        y = [one(eltype(x))]
-        return (T_sat,v_l,v_v,y)
+        return (T_sat,v_l,v_v,Vector{eltype(x)}(x))
     end
     x_r = x[idx_r]
     model_r = __tpflash_cache_model(_model_r,p,NaN,x,:vle)

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -141,8 +141,7 @@ function dew_pressure(model::EoSModel, T, y, method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,y)
     if length(_model_r) == 1 && !is_pseudo_pure(model)
         (P_sat,v_l,v_v) = saturation_pressure(_model_r,T)
-        x = [one(eltype(y))]
-        return (P_sat,v_l,v_v,x)
+        return (P_sat,v_l,v_v,Vector{eltype(y)}(y))
     end
     y_r = y[idx_r]
     model_r = __tpflash_cache_model(_model_r,NaN,T,y,:vle)
@@ -327,7 +326,7 @@ function dew_temperature(model::EoSModel,p,x;kwargs...)
     return dew_temperature(model,p,x,method)
 end
 
-function dew_temperature(model::EoSModel, p , x, T0::Number)
+function dew_temperature(model::EoSModel, p, x, T0::Number)
     moles_positivity(x)
     kwargs = (;T0)
     method = init_preferred_method(dew_temperature,model,kwargs)
@@ -342,8 +341,7 @@ function dew_temperature(model::EoSModel,p,y,method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,y)
     if length(_model_r) == 1 && !is_pseudo_pure(model)
         (T_sat,v_l,v_v) = saturation_temperature(_model_r,p)
-        x = [one(eltype(y))]
-        return (T_sat,v_l,v_v,x)
+        return (T_sat,v_l,v_v,Vector{eltype(y)}(y))
     end
     y_r = y[idx_r]
     model_r = __tpflash_cache_model(_model_r,p,NaN,y,:vle)

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -860,6 +860,9 @@ end
         @test Clapeyron.bubble_pressure(system1,T,z,Clapeyron.ActivityBubblePressure(p0 = 5e4))[1] ≈ pres1 rtol = 1E-6
         @test Clapeyron.bubble_pressure(system1,T,z,Clapeyron.ActivityBubblePressure(p0 = 5e4,y0 = [0.6,0.4]))[1] ≈ pres1 rtol = 1E-6
         GC.gc()
+
+        #602
+        @test Clapeyron.bubble_pressure(system1,T,[1.,0.])[4] == [1.,0.]
     end
 
     @testset "bubble temperature" begin
@@ -875,6 +878,9 @@ end
         @test Clapeyron.bubble_temperature(system1,p2,z,Clapeyron.FugBubbleTemperature(T0 = 450,y0 = [0.75,0.25]))[1] ≈ Tres1 rtol = 1E-6
         @test Clapeyron.bubble_temperature(system1,p2,z,Clapeyron.FugBubbleTemperature(itmax_newton = 1))[1] ≈ Tres1 rtol = 1E-6
         GC.gc()
+
+        #602
+        @test Clapeyron.bubble_temperature(system1,p2,[1.,0.])[4] == [1.,0.]
     end
 
     @testset "dew pressure" begin
@@ -897,6 +903,9 @@ end
         @test Clapeyron.dew_pressure(system1,T2,z,Clapeyron.ActivityDewPressure(p0 = 1.5e6))[1] ≈ pres2 rtol = 1E-3
         @test Clapeyron.dew_pressure(system1,T2,z,Clapeyron.ActivityDewPressure(p0 = 1.5e6,x0 = [0.1,0.9]))[1] ≈ pres2 rtol = 1E-3
         GC.gc()
+
+        #602
+        @test Clapeyron.dew_pressure(system1,T2,[1.,0.])[4] == [1.,0.]
     end
 
     @testset "dew temperature" begin
@@ -912,6 +921,9 @@ end
         @test Clapeyron.dew_temperature(system1,p2,z,Clapeyron.FugDewTemperature(T0 = 450,x0 = [0.1,0.9]))[1] ≈ Tres2 rtol = 1E-6
         @test Clapeyron.dew_temperature(system1,p2,z,Clapeyron.FugDewTemperature(itmax_newton = 2))[1] ≈ Tres2 rtol = 1E-6
         GC.gc()
+
+        #602
+        @test Clapeyron.dew_temperature(system1,p2,[1.,0.])[4] == [1.,0.]
 
         #413
         fluid413 = cPR(["Propane","Isopentane"],idealmodel=ReidIdeal);


### PR DESCRIPTION
The original purpose of `27f8ca85ded7b9cf1b73ea118119c6495eb2d563` was to fix a type inconsistency regarding the fourth return value (a vector) across the "fast path" and "general path" for the four functions:
- `bubble_pressure`
- `bubble_temperature`
- `dew_pressure`, and 
- `dew_temperature` 

when `length(_model_r) == 1`. The general path returns a `Vector{eltype(x)}`, whereas the fast path originally returned the input vector `x` as-is; since `x` could be a `StaticVector`, this created a mismatch with the `Vector` type returned by the general path, leading to unstable type inference by the compiler.

This commit preserves that fix for type stability and also resolves the issue of inconsistent return vector lengths identified in #602.

Regression tests added.