### PR TITLE
Fix type stablility bubble pressure

### DIFF
--- a/src/methods/property_solvers/multicomponent/bubble_point.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point.jl
@@ -443,8 +443,7 @@ function bubble_pressure(model::EoSModel, T, x, method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,x)
     if length(_model_r)==1 && !is_pseudo_pure(model)
         (P_sat,v_l,v_v) = saturation_pressure(_model_r,T)
-        y = [one(eltype(x))]
-        return (P_sat,v_l,v_v,y)
+        return (P_sat,v_l,v_v,Vector{eltype(x)}(x))
     end
     x_r = x[idx_r]
     model_r = __tpflash_cache_model(_model_r,NaN,T,x,:vle)
@@ -643,8 +642,7 @@ function bubble_temperature(model::EoSModel, p, x, method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,x)
     if length(_model_r) == 1 && !is_pseudo_pure(model)
         (T_sat,v_l,v_v) = saturation_temperature(_model_r,p)
-        y = [one(eltype(x))]
-        return (T_sat,v_l,v_v,y)
+        return (T_sat,v_l,v_v,Vector{eltype(x)}(x))
     end
     x_r = x[idx_r]
     model_r = __tpflash_cache_model(_model_r,p,NaN,x,:vle)

--- a/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/bubble_point/bubble_chempot.jl
@@ -77,6 +77,24 @@ function ChemPotBubblePressure(;vol0 = nothing,
     end
 end
 
+function _bubbledew_chempot_solve(f!, v0::Vector{T}, lb::Vector{T}, ub::Vector{T}, method, ::Val{N}) where {T,N}
+    # Function barrier to specialize Chunk{N}, keeping Solvers.nlsolve type-stable and preventing the N-dependent result r from escaping into bubble_pressure_impl.
+    r = Solvers.nlsolve(f!, v0,
+        LineSearch(Newton2(v0), BoundedLineSearch(lb, ub)),
+        NLSolvers.NEqOptions(method),
+        ForwardDiff.Chunk{N}()
+    )
+    sol = Solvers.x_sol(r)::Vector{T}
+    converged = __check_convergence(r)::Bool
+
+    if method.verbose
+        r_str = repr("text/plain",r)
+        @info "$r_str"
+    end
+
+    return sol, converged
+end
+
 function bubble_pressure_impl(model::EoSModel, T, x,method::ChemPotBubblePressure)
     volatiles = comps_in_equilibria(component_list(model),method.nonvolatiles)
     p0,vl,vv,y0 = bubble_pressure_init(model,T,x,method.vol0,method.p0,method.y0,volatiles,method.verbose)
@@ -107,19 +125,9 @@ function bubble_pressure_impl(model::EoSModel, T, x,method::ChemPotBubblePressur
     f! = let model = model, model_y = model_y, T=T, x=x, volatiles=volatiles, idx_max=idx_max
         (F,z) -> Obj_bubble_pressure(model, model_y, F, T, z[1], z[2], x, @view(z[3:end]), volatiles, idx_max)
     end
-    r = Solvers.nlsolve(f!, v0,
-        LineSearch(Newton2(v0),BoundedLineSearch(lb,ub)),
-        NLSolvers.NEqOptions(method),
-        ForwardDiff.Chunk{min(length(v0), 8)}()
-    )
-    sol = Solvers.x_sol(r)
+    sol, converged = _bubbledew_chempot_solve(f!, v0, lb, ub, method, Val(min(length(v0), 8)))
 
-    if method.verbose
-        r_str = repr("text/plain",r)
-        @info "$r_str"
-    end
-
-    !__check_convergence(r) && (sol .= NaN)
+    !converged && (sol .= NaN)
     v_l = v_from_η(model,sol[1],T,x)
     y_r = FractionVector(@view(sol[3:end]),idx_max)
     v_v = v_from_η(model,model_y,sol[2],T,y_r)
@@ -258,20 +266,9 @@ function bubble_temperature_impl(model::EoSModel,p,x,method::ChemPotBubbleTemper
     f! = let model = model, model_y = model_y, p=p, x=x, volatiles=volatiles, idx_max=idx_max
         (F,z) -> Obj_bubble_temperature(model, model_y, F, p, z[1], z[2], z[3], x, @view(z[4:end]), volatiles, idx_max)
     end
-    r = Solvers.nlsolve(f!, v0,
-        LineSearch(Newton2(v0),Solvers.BoundedLineSearch(lb,ub)), 
-        NLSolvers.NEqOptions(method),
-        ForwardDiff.Chunk{min(length(v0), 8)}()
-    )
+    sol, converged = _bubbledew_chempot_solve(f!, v0, lb, ub, method, Val(min(length(v0), 8)))
 
-    sol = Solvers.x_sol(r)
-
-    if method.verbose
-        r_str = repr("text/plain",r)
-        @info "$r_str"
-    end
-    
-    !__check_convergence(r) && (sol .= NaN)
+    !converged && (sol .= NaN)
     T = sol[1]
     y_r = FractionVector(@view(sol[4:end]), idx_max)
     v_l = v_from_η(model, sol[2], T, x)

--- a/src/methods/property_solvers/multicomponent/dew_point.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point.jl
@@ -141,8 +141,7 @@ function dew_pressure(model::EoSModel, T, y, method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,y)
     if length(_model_r) == 1 && !is_pseudo_pure(model)
         (P_sat,v_l,v_v) = saturation_pressure(_model_r,T)
-        x = [one(eltype(y))]
-        return (P_sat,v_l,v_v,x)
+        return (P_sat,v_l,v_v,Vector{eltype(y)}(y))
     end
     y_r = y[idx_r]
     model_r = __tpflash_cache_model(_model_r,NaN,T,y,:vle)
@@ -327,7 +326,7 @@ function dew_temperature(model::EoSModel,p,x;kwargs...)
     return dew_temperature(model,p,x,method)
 end
 
-function dew_temperature(model::EoSModel, p , x, T0::Number)
+function dew_temperature(model::EoSModel, p, x, T0::Number)
     moles_positivity(x)
     kwargs = (;T0)
     method = init_preferred_method(dew_temperature,model,kwargs)
@@ -342,8 +341,7 @@ function dew_temperature(model::EoSModel,p,y,method::ThermodynamicMethod)
     _model_r,idx_r = index_reduction(model,y)
     if length(_model_r) == 1 && !is_pseudo_pure(model)
         (T_sat,v_l,v_v) = saturation_temperature(_model_r,p)
-        x = [one(eltype(y))]
-        return (T_sat,v_l,v_v,x)
+        return (T_sat,v_l,v_v,Vector{eltype(y)}(y))
     end
     y_r = y[idx_r]
     model_r = __tpflash_cache_model(_model_r,p,NaN,y,:vle)

--- a/src/methods/property_solvers/multicomponent/dew_point/dew_chempot.jl
+++ b/src/methods/property_solvers/multicomponent/dew_point/dew_chempot.jl
@@ -100,19 +100,9 @@ function dew_pressure_impl(model::EoSModel, T, y,method::ChemPotDewPressure)
     f! = let model=model, model_x=model_x, T=T, y=y, condensables=condensables, idx_max=idx_max
         (F,z) -> Obj_dew_pressure(model, model_x, F, T, z[1], z[2], @view(z[3:end]), y, condensables, idx_max)
     end
-    r = Solvers.nlsolve(f!, v0,
-            LineSearch(Newton2(v0),BoundedLineSearch(lb,ub)),
-            NLSolvers.NEqOptions(method),
-            ForwardDiff.Chunk{min(length(v0), 8)}()
-        )
-    sol = Solvers.x_sol(r)
+    sol, converged = _bubbledew_chempot_solve(f!, v0, lb, ub, method, Val(min(length(v0), 8)))
 
-    if method.verbose
-        r_str = repr("text/plain",r)
-        @info "$r_str"
-    end
-
-    !__check_convergence(r) && (sol .= NaN)
+    !converged && (sol .= NaN)
     x_r = FractionVector(@view(sol[3:end]),idx_max)
     v_l = v_from_η(model,model_x,sol[1],T,x_r)
     v_v = v_from_η(model,sol[2],T,y)
@@ -246,19 +236,9 @@ function dew_temperature_impl(model::EoSModel,p,y,method::ChemPotDewTemperature)
     f! = let model=model, model_x=model_x, p=p, y=y, condensables=condensables, idx_max=idx_max
         (F,z) -> Obj_dew_temperature(model, model_x, F, p, z[1], z[2], z[3], @view(z[4:end]), y, condensables, idx_max)
     end
-    r = Solvers.nlsolve(f!, v0,
-            LineSearch(Newton2(v0),BoundedLineSearch(lb,ub)),
-            NLSolvers.NEqOptions(method),
-            ForwardDiff.Chunk{min(length(v0), 8)}()
-        )
-    sol = Solvers.x_sol(r)
+    sol, converged = _bubbledew_chempot_solve(f!, v0, lb, ub, method, Val(min(length(v0), 8)))
 
-    if method.verbose
-        r_str = repr("text/plain",r)
-        @info "$r_str"
-    end
-
-    !__check_convergence(r) && (sol .= NaN)
+    !converged && (sol .= NaN)
     T   = sol[1]
     x_r = FractionVector(@view(sol[4:end]),idx_max)
     v_l = v_from_η(model,model_x,sol[2],T,x_r)

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -860,6 +860,9 @@ end
         @test Clapeyron.bubble_pressure(system1,T,z,Clapeyron.ActivityBubblePressure(p0 = 5e4))[1] ≈ pres1 rtol = 1E-6
         @test Clapeyron.bubble_pressure(system1,T,z,Clapeyron.ActivityBubblePressure(p0 = 5e4,y0 = [0.6,0.4]))[1] ≈ pres1 rtol = 1E-6
         GC.gc()
+
+        #602
+        @test Clapeyron.bubble_pressure(system1,T,[1.,0.])[4] == [1.,0.]
     end
 
     @testset "bubble temperature" begin
@@ -875,6 +878,9 @@ end
         @test Clapeyron.bubble_temperature(system1,p2,z,Clapeyron.FugBubbleTemperature(T0 = 450,y0 = [0.75,0.25]))[1] ≈ Tres1 rtol = 1E-6
         @test Clapeyron.bubble_temperature(system1,p2,z,Clapeyron.FugBubbleTemperature(itmax_newton = 1))[1] ≈ Tres1 rtol = 1E-6
         GC.gc()
+
+        #602
+        @test Clapeyron.bubble_temperature(system1,p2,[1.,0.])[4] == [1.,0.]
     end
 
     @testset "dew pressure" begin
@@ -897,6 +903,9 @@ end
         @test Clapeyron.dew_pressure(system1,T2,z,Clapeyron.ActivityDewPressure(p0 = 1.5e6))[1] ≈ pres2 rtol = 1E-3
         @test Clapeyron.dew_pressure(system1,T2,z,Clapeyron.ActivityDewPressure(p0 = 1.5e6,x0 = [0.1,0.9]))[1] ≈ pres2 rtol = 1E-3
         GC.gc()
+
+        #602
+        @test Clapeyron.dew_pressure(system1,T2,[1.,0.])[4] == [1.,0.]
     end
 
     @testset "dew temperature" begin
@@ -912,6 +921,9 @@ end
         @test Clapeyron.dew_temperature(system1,p2,z,Clapeyron.FugDewTemperature(T0 = 450,x0 = [0.1,0.9]))[1] ≈ Tres2 rtol = 1E-6
         @test Clapeyron.dew_temperature(system1,p2,z,Clapeyron.FugDewTemperature(itmax_newton = 2))[1] ≈ Tres2 rtol = 1E-6
         GC.gc()
+
+        #602
+        @test Clapeyron.dew_temperature(system1,p2,[1.,0.])[4] == [1.,0.]
 
         #413
         fluid413 = cPR(["Propane","Isopentane"],idealmodel=ReidIdeal);


### PR DESCRIPTION
```julia
using Clapeyron
using InteractiveUtils

model = PR(["ethanol", "water"])
T = 300.0
x_pure_endpoint = [1.0, 0.0]

@code_warntype bubble_pressure(model, T, x_pure_endpoint)
```

PR#603 only fixes part of the type instability, these functions still return `NTuple{4,Any}`.
This PR completely fixes the stability of return value types of four functions including dew point pressure.
Now they return:
```
dew_pressure_impl -> Tuple{Float64, Float64, Float64, Vector{Float64}}
dew_pressure -> Tuple{Float64, Float64, Float64, Vector{Float64}}
dew_temperature_impl -> Tuple{Float64, Float64, Float64, Vector{Float64}}
dew_temperature -> Tuple{Float64, Float64, Float64, Vector{Float64}}
```

To put it simply, since the type value of `ForwardDiff.Chunk{min(length(v0), 8)}` in the following function is dynamically calculated, the return value is inferred to be `Any`, polluting all downstream type inferences. I made a function barrier in this PR.
```julia
    r = Solvers.nlsolve(f!, v0,
        LineSearch(Newton2(v0),BoundedLineSearch(lb,ub)),
        NLSolvers.NEqOptions(method),
        ForwardDiff.Chunk{min(length(v0), 8)}()
    )
```

ForwardDiff.jl has related issues. They have discovered that dynamic calculation of Chunk will lead to type instability, which is almost impossible to solve (dynamic and specialization are always opposites). Function barriers are a reasonable solution.

I will add a regression test to this PR later.