### PR TITLE
Replace lnϕ with modified_lnϕ also in fallback

### DIFF
--- a/src/methods/property_solvers/multicomponent/fugacity.jl
+++ b/src/methods/property_solvers/multicomponent/fugacity.jl
@@ -128,13 +128,13 @@ function _fug_OF_ss(model::EoSModel,p,T,x,y,vol0,data::FugData,cache)
             ss_count += 1
             lnϕx, volx = modified_lnϕ(model, p, T, _x, Hϕx, vol0=volx, phase = phasex)
             if isnan(volx)
-                lnϕx, volx = lnϕ(model, 1.1p, T, _x, Hϕx, phase = phasex)
+                lnϕx, volx = modified_lnϕ(model, 1.1p, T, _x, Hϕx, phase = phasex)
             end
             lnK .= lnϕx
 
             lnϕy, voly = modified_lnϕ(model, p, T, _y, Hϕx, vol0=voly, phase = phasey)
             if isnan(voly)
-                lnϕy, voly = lnϕ(model, p, T, _y, Hϕx, phase = phasey)
+                lnϕy, voly = modified_lnϕ(model, p, T, _y, Hϕx, phase = phasey)
             end
             lnK .-= lnϕy
 


### PR DESCRIPTION
This should be modified_lnϕ right? If the volumes are NaN, the old version throw an error for activity models (instead of NaN for failed solve)