### PR TITLE
Fix type instability in pure saturation initialization

### DIFF
--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -330,7 +330,7 @@ function x0_sat_pure_virial(model,T,z = SA[1.0])
         #"zero-pressure" volume, apply corresponding strategy
         return x0_sat_pure_near0(model,T,z,vl;B = B)
     else
-        psat, _, vv_B = x0_sat_pure_near0(model,T,z,vl,B,false)
+        psat, _, vv_B = x0_sat_pure_near0(model,T,z,vl;B=B,refine_vl=false)
         if T̃/T̃max > 0.55
             B_vdw = ∑z*(b - a/RT)
             vv_vdw_2b = -2*B_vdw
@@ -420,13 +420,8 @@ Calculates initial points for pure saturation pressure, using a zero-pressure vo
 If `refine_vl` is set to `true`, then the liquid volume will be recalculated using the calculated saturation pressure, otherwise it will be returned as is.
 """
 function x0_sat_pure_near0(model, T, z = SA[1.0], vl0 = volume(model,zero(T),T,z,phase=:l);
-    B = second_virial_coefficient(model,T,z),
-    refine_vl = true,
+    B = second_virial_coefficient(model,T,z), refine_vl = true
 )
-    return x0_sat_pure_near0(model, T, z, vl0, B, refine_vl)
-end
-
-function x0_sat_pure_near0(model, T, z, vl0, B, refine_vl::Bool)
     R̄ = Rgas(model)
     RT = R̄*T
     n = sum(z)

--- a/src/methods/initial_guess.jl
+++ b/src/methods/initial_guess.jl
@@ -215,9 +215,10 @@ function x0_sat_pure(model,T)
         return x0_sat_pure(satmodel,T)
     end
     if !has_fast_crit_pure(model)
-    _,vl,vv = x0_sat_pure_virial(model,T)
+        _,vl,vv = x0_sat_pure_virial(model,T)
     else
-    _,vl,vv = x0_sat_pure_crit(model,T)
+        R = Base.promote_eltype(model,T)
+        _,vl,vv = x0_sat_pure_crit(model,T)::NTuple{3,R}
     end
     return vl,vv
 end
@@ -236,7 +237,9 @@ function x0_sat_pure(model,T,crit)
     if isnothing(crit)
         _,vl,vv = x0_sat_pure_virial(model,T)
     else
-        _,vl,vv = x0_sat_pure_crit(model,T,crit)
+        Tc,Pc,Vc = crit
+        R = Base.promote_eltype(model,T,Tc,Pc,Vc)
+        _,vl,vv = x0_sat_pure_crit(model,T,crit)::NTuple{3,R}
     end
     return vl,vv
 end
@@ -327,7 +330,7 @@ function x0_sat_pure_virial(model,T,z = SA[1.0])
         #"zero-pressure" volume, apply corresponding strategy
         return x0_sat_pure_near0(model,T,z,vl;B = B)
     else
-        psat,_,vv_B = x0_sat_pure_near0(model,T,z,vl,B = B,refine_vl = false)
+        psat, _, vv_B = x0_sat_pure_near0(model,T,z,vl,B,false)
         if T̃/T̃max > 0.55
             B_vdw = ∑z*(b - a/RT)
             vv_vdw_2b = -2*B_vdw
@@ -416,7 +419,14 @@ end
 Calculates initial points for pure saturation pressure, using a zero-pressure volume approach.
 If `refine_vl` is set to `true`, then the liquid volume will be recalculated using the calculated saturation pressure, otherwise it will be returned as is.
 """
-function x0_sat_pure_near0(model, T, z = SA[1.0],vl0 = volume(model,zero(T),T,z,phase = :l);B = second_virial_coefficient(model,T,z), refine_vl = true)
+function x0_sat_pure_near0(model, T, z = SA[1.0], vl0 = volume(model,zero(T),T,z,phase=:l);
+    B = second_virial_coefficient(model,T,z),
+    refine_vl = true,
+)
+    return x0_sat_pure_near0(model, T, z, vl0, B, refine_vl)
+end
+
+function x0_sat_pure_near0(model, T, z, vl0, B, refine_vl::Bool)
     R̄ = Rgas(model)
     RT = R̄*T
     n = sum(z)

--- a/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
@@ -41,7 +41,9 @@ function saturation_pressure(model::EoSModel,T,method::SaturationMethod)
     single_component_check(saturation_pressure,model)
     T = T*(T/T)*oneunit(eltype(model))
     satmodel = saturation_model(model)
-    satmodel !== model && saturation_pressure(satmodel,T,method)
+    if satmodel !== model
+        return saturation_pressure(satmodel, T, method)
+    end
     if has_a_res(model)
         λmodel,λT = primalval(model),primalval(T)
         λresult = saturation_pressure_impl(λmodel,λT,method)
@@ -171,7 +173,7 @@ function saturation_temperature(model::EoSModel, p, T0::Number)
     saturation_temperature(model,p,method)
 end
 
-function saturation_temperature_ad(result,tup,tup_primal)    
+function saturation_temperature_ad(result,tup,tup_primal)
     f(x,tups) = begin
         model,p = tups
         T,vl,vv = x

--- a/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
+++ b/src/methods/property_solvers/singlecomponent/saturation/saturation.jl
@@ -149,7 +149,7 @@ end
 function saturation_temperature(model,p,method::SaturationMethod)
     satmodel = saturation_model(model)
     if satmodel !== model
-        return saturation_temperature(satmodel,p;method)
+        return saturation_temperature(satmodel,p,method)
     end
     single_component_check(crit_pure,model)
     p = p*p/p

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -987,6 +987,23 @@ end
     end
     GC.gc()
 
+    @testset "bubble/dew type stability" begin
+        admodel = cPR(["R134a","propane"])
+        @test @inferred(bubble_pressure(admodel, 300., [0.5, 0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+        @test @inferred(bubble_temperature(admodel, 300., [1.,0.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+        @test @inferred(dew_pressure(admodel, 300., [0.,1.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+        @test @inferred(dew_temperature(admodel, 300., [0.5,0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+    end
+
+    @testset "pure saturation and bubble-pressure type stability" begin
+        model_r, _ = Clapeyron.index_reduction(system1, [1.0, 0.0])
+        method = Clapeyron.ChemPotVSaturation()
+        T = 313.15
+        @test @inferred(Clapeyron.x0_sat_pure_virial(model_r, T)) isa NTuple{3,Float64}
+        @test @inferred(saturation_pressure(model_r, T, method)) isa NTuple{3,Float64}
+        @test @inferred(bubble_pressure(system1, T, [1.0, 0.0])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+    end
+
     @testset "bubble/dew implicit AD" begin
         admodel = cPR(["R134a","propane"])
         bp(T) = first(bubble_pressure(admodel,300.0*T,[0.5,0.5]))
@@ -1007,12 +1024,5 @@ end
         @test Clapeyron.Solvers.derivative(dpge,1.0) ≈ Clapeyron.derivx(dpge,1.0) rtol = 1e-5
         @test Clapeyron.Solvers.derivative(btge,1.0) ≈ Clapeyron.derivx(btge,1.0) rtol = 1e-5
         @test Clapeyron.Solvers.derivative(dtge,1.0) ≈ Clapeyron.derivx(dtge,1.0) rtol = 1e-5
-    end
-
-    @testset "bubble/dew type stability" begin
-        @test @inferred(bubble_pressure(admodel, 300., [0.5, 0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-        @test @inferred(bubble_temperature(admodel, 300., [1.,0.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-        @test @inferred(dew_pressure(admodel, 300., [0.,1.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-        @test @inferred(dew_temperature(admodel, 300., [0.5,0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
     end
 end

--- a/test/test_methods_api_flash.jl
+++ b/test/test_methods_api_flash.jl
@@ -987,23 +987,6 @@ end
     end
     GC.gc()
 
-    @testset "bubble/dew type stability" begin
-        admodel = cPR(["R134a","propane"])
-        @test @inferred(bubble_pressure(admodel, 300., [0.5, 0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-        @test @inferred(bubble_temperature(admodel, 300., [1.,0.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-        @test @inferred(dew_pressure(admodel, 300., [0.,1.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-        @test @inferred(dew_temperature(admodel, 300., [0.5,0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-    end
-
-    @testset "pure saturation and bubble-pressure type stability" begin
-        model_r, _ = Clapeyron.index_reduction(system1, [1.0, 0.0])
-        method = Clapeyron.ChemPotVSaturation()
-        T = 313.15
-        @test @inferred(Clapeyron.x0_sat_pure_virial(model_r, T)) isa NTuple{3,Float64}
-        @test @inferred(saturation_pressure(model_r, T, method)) isa NTuple{3,Float64}
-        @test @inferred(bubble_pressure(system1, T, [1.0, 0.0])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
-    end
-
     @testset "bubble/dew implicit AD" begin
         admodel = cPR(["R134a","propane"])
         bp(T) = first(bubble_pressure(admodel,300.0*T,[0.5,0.5]))
@@ -1024,5 +1007,24 @@ end
         @test Clapeyron.Solvers.derivative(dpge,1.0) ≈ Clapeyron.derivx(dpge,1.0) rtol = 1e-5
         @test Clapeyron.Solvers.derivative(btge,1.0) ≈ Clapeyron.derivx(btge,1.0) rtol = 1e-5
         @test Clapeyron.Solvers.derivative(dtge,1.0) ≈ Clapeyron.derivx(dtge,1.0) rtol = 1e-5
+    end
+
+    @testset "bubble/dew type stability" begin
+        saturation_temperature(cPR("isobutane"), 1.7855513185537157e6; crit_retry = false)
+
+        admodel = cPR(["R134a","propane"])
+        @test @inferred(bubble_pressure(admodel, 300., [0.5, 0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+        @test @inferred(bubble_temperature(admodel, 300., [1.,0.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+        @test @inferred(dew_pressure(admodel, 300., [0.,1.])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+        @test @inferred(dew_temperature(admodel, 300., [0.5,0.5])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
+    end
+
+    @testset "pure saturation and bubble-pressure type stability" begin
+        model_r, _ = Clapeyron.index_reduction(system1, [1.0, 0.0])
+        method = Clapeyron.ChemPotVSaturation()
+        T = 313.15
+        @test @inferred(Clapeyron.x0_sat_pure_virial(model_r, T)) isa NTuple{3,Float64}
+        @test @inferred(saturation_pressure(model_r, T, method)) isa NTuple{3,Float64}
+        @test @inferred(bubble_pressure(system1, T, [1.0, 0.0])) isa Tuple{Float64,Float64,Float64,Vector{Float64}}
     end
 end


### PR DESCRIPTION
This PR fixes type instability in the pure saturation initialization path that propagates into `bubble_pressure`.

Because the reduced model type does not encode its number of components, Julia must infer both the pure-component fast path and the general mixture path. Imprecise inference in the pure branch can therefore affect `bubble_pressure` even when that branch is not taken at runtime.

The numerical algorithms and results are unchanged; the affected methods (bubble/dew temperature/pressure) now infer concrete return types. (including Case B in #605)

## Changes

### 1. ~Use a positional internal method for `x0_sat_pure_near0`~

*It has been determined that this is not the root cause; the changes have been rolled back in [b43a068](https://github.com/ClapeyronThermo/Clapeyron.jl/pull/607/commits/b43a06832e49a16606cea823440da5ba3f3bd40e).*

~The internal call in `x0_sat_pure_virial` previously passed `B` and `refine_vl` as keyword arguments:~

```julia
x0_sat_pure_near0(model,T,z,vl;B=B,refine_vl=false)
````

~This call caused `x0_sat_pure_virial` to infer an imprecise return type in the affected call graph.~

> ~The keyword call is semantically valid, and `x0_sat_pure_near0` itself has a concrete return type when inferred independently. However, in the affected recursive call graph, Julia 1.10 fails to propagate that concrete return type through the keyword-dispatch call site. Inference becomes incomplete at this boundary, causing `x0_sat_pure_virial` to receive an imprecise tuple return type.~

~The public keyword interface is retained as a wrapper, while the internal call now uses a positional implementation method:~

```julia
x0_sat_pure_near0(model,T,z,vl,B,false)
```

~This preserves the existing API while restoring inference of:~

```julia
Tuple{Float64,Float64,Float64}
```

### 2. Add generic return-type barriers for `x0_sat_pure_crit`

`x0_sat_pure_crit` returns a concrete three-element numeric tuple when inferred independently, but its return type could degrade to `Tuple{Any,Any,Any}` inside the larger saturation solver call graph.

The results are now asserted as:

```julia
NTuple{3,R}
```

where `R` is obtained with `Base.promote_eltype` from the model, temperature, and critical-point values.

This keeps the code generic for numeric types other than `Float64` while preventing imprecise inference from propagating through `x0_sat_pure`.

### 3. Return the delegated `saturation_pressure` result

When `saturation_model(model)` returned a different model, the previous code called the delegated method but discarded its result:

```julia
satmodel !== model && saturation_pressure(satmodel,T,method)
```

The branch now returns immediately:

```julia
if satmodel !== model
    return saturation_pressure(satmodel,T,method)
end
```

This prevents execution from continuing with the original model after delegation.

## Regression tests

The added tests verify concrete inference for:

```julia
x0_sat_pure_virial(model_r,T)
saturation_pressure(model_r,T,method)
bubble_pressure(system,T,[1.0,0.0])
```

The expected inferred types are:

```julia
NTuple{3,Float64}
NTuple{3,Float64}
Tuple{Float64,Float64,Float64,Vector{Float64}}
```

The test case uses a binary PC-SAFT model reduced to one active component, reproducing the original unstable `bubble_pressure` path.

## Test ordering note

The type-stability tests are intentionally placed before the implicit-AD tests.

On Julia 1.10, executing the Dual-valued `bubble_temperature` or `dew_temperature` path first can cause later Float64 inference to degrade to `Tuple{Any,Any,Any,...}`. If the Float64 path is inferred first, it remains concrete after the Dual path is executed.

This appears to be an inference-order issue in the Julia compiler rather than a Clapeyron state or cache mutation. I plan to prepare a separate minimal reproducer and report it to the Julia repository.